### PR TITLE
Fixed typo where 'rocker' was spelt 'rocket'.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2164,7 +2164,7 @@ Ring terminals and earth assemblies for DiBond panels.
 ---
 <a name="Rockers"></a>
 ## Rockers
-Rocket switch. Also used for neon indicator in the same form factor.
+Rocker switch. Also used for neon indicator in the same form factor.
 
 
 [vitamins/rockers.scad](vitamins/rockers.scad) Object definitions.

--- a/vitamins/rocker.scad
+++ b/vitamins/rocker.scad
@@ -18,7 +18,7 @@
 //
 
 //
-//! Rocket switch. Also used for neon indicator in the same form factor.
+//! Rocker switch. Also used for neon indicator in the same form factor.
 //
 include <../core.scad>
 use <spade.scad>


### PR DESCRIPTION
'Rocker' was misspelt in two places.