### PR TITLE
Initial submission of E2020 aluminium extrusion.

### DIFF
--- a/lib.scad
+++ b/lib.scad
@@ -62,6 +62,7 @@ include <vitamins/spools.scad>
 include <vitamins/mains_sockets.scad>
 include <vitamins/ldrs.scad>
 include <vitamins/geared_steppers.scad>
+include <vitamins/extrusions.scad>
 
 use <vitamins/jack.scad>
 use <vitamins/meter.scad>

--- a/libtest.scad
+++ b/libtest.scad
@@ -32,6 +32,7 @@ use <tests/cable_strips.scad>
 use <tests/components.scad>
 use <tests/d_connectors.scad>
 use <tests/displays.scad>
+use <tests/extrusions.scad>
 use <tests/fans.scad>
 use <tests/fuseholder.scad>
 use <tests/geared_steppers.scad>
@@ -152,7 +153,7 @@ leadnuts_y = pillars_y + 40;
 pulleys_y = leadnuts_y +40;
 hot_ends_y = pulleys_y + 60;
 linear_bearings_y = hot_ends_y + 50;
-sheets_y = linear_bearings_y + 50;
+sheets_y = linear_bearings_y + 100;
 pcbs_y = sheets_y + 40;
 displays_y = pcbs_y + 150;
 fans_y = displays_y + 100;
@@ -201,6 +202,10 @@ translate([x0, pulleys_y])
 translate([x0, linear_bearings_y]) {
     linear_bearings();
     rods();
+}
+
+translate([x0+120, linear_bearings_y+30]) {
+    extrusions();
 }
 
 translate([x0 + 10, hot_ends_y])

--- a/tests/extrusions.scad
+++ b/tests/extrusions.scad
@@ -1,0 +1,30 @@
+//
+// NopSCADlib Copyright Chris Palmer 2020
+// nop.head@gmail.com
+// hydraraptor.blogspot.com
+//
+// This file is part of NopSCADlib.
+//
+// NopSCADlib is free software: you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// NopSCADlib is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with NopSCADlib.
+// If not, see <https://www.gnu.org/licenses/>.
+//
+include <../core.scad>
+use <../utils/layout.scad>
+
+include <../vitamins/extrusions.scad>
+
+module extrusions()
+    layout([for(e = extrusions) extrusion_width(e)], 10)
+        extrusion(extrusions[$i], 80);
+
+if ($preview)
+    extrusions();
+

--- a/vitamins/extrusion.scad
+++ b/vitamins/extrusion.scad
@@ -1,0 +1,128 @@
+//
+// NopSCADlib Copyright Chris Palmer 2020
+// nop.head@gmail.com
+// hydraraptor.blogspot.com
+//
+// This file is part of NopSCADlib.
+//
+// NopSCADlib is free software: you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// NopSCADlib is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with NopSCADlib.
+// If not, see <https://www.gnu.org/licenses/>.
+
+//
+//! Aluminium  extrusion.
+//
+include <../core.scad>
+
+function extrusion_width(type)          = type[1];   //! Width of extrusion
+function extrusion_height(type)         = type[2];   //! Height of extrusion
+function extrusion_center_hole(type)    = type[3];   //! Diameter of center hole
+function extrusion_corner_hole(type)    = type[4];   //! Diameter of corner hole
+function extrusion_center_square(type)  = type[5];   //! Size of center square
+function extrusion_channel_width(type)  = type[6];   //! Channel width
+function extrusion_channel_width_internal(type)  = type[7];   //! Internal channel width
+function extrusion_tab_thickness(type)  = type[8];   //! Tab thickness
+function extrusion_spar_thickness(type) = type[9];   //! Spar thickness
+function extrusion_fillet(type)         = type[10];  //! Radius of corner fillet
+
+module extrusion_cross_section(type, cornerHole) {
+
+    module extrusion_corner(type, cornerHole) {
+        width = extrusion_width(type);
+        tabThickness = extrusion_tab_thickness(type);
+        sparThickness = extrusion_spar_thickness(type);
+        centerSquare = extrusion_center_square(type);
+        channelWidth = extrusion_channel_width(type);
+        fillet = extrusion_fillet(type);
+        cornerSize = (width-channelWidth)/2;
+        cornerSquare = (width-extrusion_channel_width_internal(type))/2;
+        cornerHoleDiameter =extrusion_corner_hole(type);
+
+        translate([-width/2,-width/2]) {
+            difference() {
+                union() {
+                    translate([fillet,0])
+                        square([cornerSize-fillet,tabThickness]);
+                    translate([0,fillet])
+                        square([tabThickness,cornerSize-fillet]);
+                    translate([fillet,fillet])
+                        circle(fillet);
+                    translate([fillet,fillet])
+                        square([cornerSquare-fillet,cornerSquare-fillet]);
+                }
+                if(cornerHole)
+                    translate([cornerSquare/2,cornerSquare/2])
+                        circle(d=cornerHoleDiameter);
+            }
+        }
+        rotate(-135) translate([centerSquare/2,-sparThickness/2]) square([sqrt(2)*(width-centerSquare-cornerSquare)/2,sparThickness]);
+    }
+
+    module extrusion_center_section(type) {
+        width = extrusion_width(type);
+        tabThickness = extrusion_tab_thickness(type);
+        sparThickness = extrusion_spar_thickness(type);
+        centerSquare = extrusion_center_square(type);
+        channelWidth = extrusion_channel_width(type);
+
+        translate([0,width/2])
+            for(angle=[225,315])
+                rotate(angle)
+                    translate([centerSquare/2,-sparThickness/2])
+                        square([sqrt(2)*(width-centerSquare)/2,sparThickness]);
+        translate([0,-width/2])
+            for(angle=[45,135])
+                rotate(angle)
+                    translate([centerSquare/2,-sparThickness/2])
+                        square([sqrt(2)*(width-centerSquare)/2,sparThickness]);
+
+        centerHeight = width-channelWidth;
+        translate([-width/2,-centerHeight/2])
+            square([tabThickness,centerHeight]);
+        translate([width/2-tabThickness,-centerHeight/2])
+            square([tabThickness,centerHeight]);
+    }
+
+
+    centerSquare = extrusion_center_square(type);
+
+    width = extrusion_width(type);
+    height = extrusion_height(type);
+    count = (height-width)/width;
+
+    for(i=[0:count])
+        translate([0,i*width+(width-height)/2])
+            difference() {
+                square([centerSquare,centerSquare],center=true);
+                circle(d=extrusion_center_hole(type));
+            }
+    translate([0,(width-height)/2])
+        for(angle=[0,90])
+            rotate(angle)
+                extrusion_corner(type, cornerHole);
+    translate([0,-(width-height)/2])
+        for(angle=[180,270])
+            rotate(angle)
+                extrusion_corner(type, cornerHole);
+    if(count>=1)
+        for(i=[1:count])
+            translate([0,i*width-height/2])
+                extrusion_center_section(type);
+}
+
+module extrusion(type, length, cornerHole = false) { //! Draw the specified extrusion
+
+    vitamin(str("extrusion(", type[0], ", ", length, "): Extrusion ", type[0], " x ", length, "mm"));
+
+    color(grey90)
+        linear_extrude(height = length)
+            extrusion_cross_section(type, cornerHole);
+}
+

--- a/vitamins/extrusions.scad
+++ b/vitamins/extrusions.scad
@@ -1,0 +1,35 @@
+//
+// NopSCADlib Copyright Chris Palmer 2020
+// nop.head@gmail.com
+// hydraraptor.blogspot.com
+//
+// This file is part of NopSCADlib.
+//
+// NopSCADlib is free software: you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// NopSCADlib is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with NopSCADlib.
+// If not, see <https://www.gnu.org/licenses/>.
+//
+//
+// Extrusion
+//
+//                   W   H    d1   d2   s  cw   cwi    t  st  f
+E2020  = [ "E2020", 20, 20,  4.2,   0,  8,  6, 12.0,   2,  2, 1 ];
+E2040  = [ "E2040", 20, 40,  4.2,   0,  8,  6, 12.0,   2,  2, 1 ];
+E2060  = [ "E2060", 20, 60,  4.2,   0,  8,  6, 12.0,   2,  2, 1 ];
+E2080  = [ "E2080", 20, 80,  4.2,   0,  8,  6, 12.0,   2,  2, 1 ];
+E3030  = [ "E3030", 30, 30,  6.8, 4.2, 12,  8, 16.5,   2,  2, 1 ];
+E3060  = [ "E3060", 30, 60,  6.8, 4.2, 12,  8, 16.5,   2,  2, 1 ];
+E4040  = [ "E4040", 40, 40, 10.5, 6.0, 15, 10, 20.0, 5.5,  3, 1 ];
+E4080  = [ "E4080", 40, 80, 10.5, 6.0, 15, 10, 20.0, 5.5,  3, 1 ];
+
+extrusions = [E2020,E2040,E2060,E2080,E3030,E3060,E4040,E4080];
+
+use <extrusion.scad>
+


### PR DESCRIPTION
Here's my initial submission for E2020 aluminium extrusion. Once accepted I can add other types (E2040, E2060, E3030 etc) and add a submission for the `readme.md`.

I've tried to follow your coding style, but let me know if you'd like any changes.

I'm not sure what your line endings policy is, you don't have a `.gitattributes` file. My submission contains Windows style (`CRLF`) line endings, but I'm quite happy to change to Unix style (`CR`) - indeed that is my preference.

Extrusion dimensions are taken from [20x20 Aluminum Extrusion - 5 Series, Base 20 (MISUMI) (KHFS5-2020-1000](https://us.misumi-ec.com/vona2/detail/110302683830/?HissuCode=KHFS5-2020-1000)