### PR TITLE
Added JST-XH connector to pcb

### DIFF
--- a/vitamins/pcb.scad
+++ b/vitamins/pcb.scad
@@ -718,6 +718,7 @@ module pcb_component(comp, cutouts = false, angle = undef) { //! Draw pcb compon
         if(show(comp, "flat_flex")) flat_flex(cutouts);
         if(show(comp, "D_plug")) if(!cutouts) translate_z(d_pcb_offset(comp[4])) d_plug(comp[4], pcb = true);
         if(show(comp, "molex_hdr")) if(!cutouts) molex_254(comp[4]);
+        if(show(comp, "jst_xh")) if(!cutouts) jst_xh_header(jst_xh_header, comp[4], param(5, false), param(6, "white"), param(7, undef));
         if(show(comp, "term254")) if(!cutouts) green_terminal(gt_2p54,comp[4], comp[5]);
         if(show(comp, "gterm35")) if(!cutouts) green_terminal(gt_3p5, comp[4], comp[5]);
         if(show(comp, "gterm635")) if(!cutouts) green_terminal(gt_6p35, comp[4], comp[5]);

--- a/vitamins/pcbs.scad
+++ b/vitamins/pcbs.scad
@@ -339,6 +339,20 @@ PERF74x51 = ["PERF74x51", "Perfboard 74 x 51mm", 74, 51, 1.0, 0, 3.0, 0, "sienna
 
 PSU12V1A = ["PSU12V1A", "PSU 12V 1A", 67, 31, 1.7, 0, 3.9, 0, "green", true, [[3.5, 3.5], [-3.5, 3.5], [-3.5, -3.5], [3.5, -3.5]], [], []];
 
-pcbs = [ExtruderPCB, PI_IO, RPI0, EnviroPlus, RPI3, ArduinoUno3, ArduinoLeonardo, Keyes5p1, PERF80x20, PERF70x50, PERF70x30, PERF60x40, PERF74x51, PSU12V1A, DuetE, Duex2, Duex5, Melzi, ZC_A0591];
+RAMPSEndstop = ["RAMPSEndstop", "RAMPS Endstop Switch",
+    40.0, 16.0, 1.6, 0, 2.54, 0, "red",  false,
+    [
+        [2, 2], [2, 13.5], [17, 13.5], [36, 13.5]
+    ],
+    [
+        [ 12,    8,   -90, "jst_xh", 3, true, "white", "silver"],
+        [ 26,   13.5,   0, "chip", 12, 4, 5.5],
+        [ 26,   10.5,   0, "chip", 12, 2, 5.5, "white"],
+        [ 27.5, 17,    15, "chip", 15, 0.5, 4.5, "silver"],
+    ],
+    []];
+
+
+pcbs = [ExtruderPCB, PI_IO, RPI0, EnviroPlus, RPI3, ArduinoUno3, ArduinoLeonardo, Keyes5p1, PERF80x20, PERF70x50, PERF70x30, PERF60x40, PERF74x51, PSU12V1A, DuetE, Duex2, Duex5, Melzi, ZC_A0591, RAMPSEndstop];
 
 use <pcb.scad>

--- a/vitamins/pin_headers.scad
+++ b/vitamins/pin_headers.scad
@@ -25,6 +25,7 @@
 //                                                         c
 //
 2p54header = ["2p54header", 2.54, 11.6, 3.2, 0.66, "gold", grey20, 8.5];
+jst_xh_header = ["JST XH header",2.5,10,3.4, 0.64, "gold", grey90, 7];
 
 pin_headers = [ 2p54header ];
 


### PR DESCRIPTION
Allows a JST-XH connector to be added to a PCB. Vertical or sideways orientation supported.

Dimensions taken from https://www.digikey.com/en/resources/datasheets/jst/xh-connector

Added RAMPSEndstop PCB to `pcbs[]`. This is probably the simplest possible test of the connector, and a useful board in itself.