### PR TITLE
Parameterised belt colors.

### DIFF
--- a/tests/belts.scad
+++ b/tests/belts.scad
@@ -67,7 +67,7 @@ module belt_test() {
     translate([-25, 0])
         layout([for(b = belts) belt_width(b)], 10)
             rotate([0, 90, 0])
-                belt(belts[$i], [[0, 0, 20], [0, 1, 20]]);
+                belt(belts[$i], [[0, 0, 20], [0, 1, 20]], belt_colour = $i%2==0 ? grey90 : grey20, tooth_colour = $i%2==0 ? grey70 : grey50);
 }
 
 if($preview)

--- a/vitamins/belt.scad
+++ b/vitamins/belt.scad
@@ -41,9 +41,7 @@ function no_point(str) = chr([for(c = str) if(c == ".") ord("p") else ord(c)]);
 // We model the belt path at the pitch radius of the pulleys and the pitch line of the belt to get an accurate length.
 // The belt is then drawn by offseting each side from the pitch line.
 //
-module belt(type, points, gap = 0, gap_pt = undef) { //! Draw a belt path given a set of points and pitch radii where the pulleys are. Closed loop unless a gap is specified
-    belt_colour = grey20;
-    tooth_colour = grey50;
+module belt(type, points, gap = 0, gap_pt = undef, belt_colour = grey20, tooth_colour = grey50) { //! Draw a belt path given a set of points and pitch radii where the pulleys are. Closed loop unless a gap is specified
     width = belt_width(type);
     pitch = belt_pitch(type);
     thickness = belt_thickness(type);


### PR DESCRIPTION
Allows user to set belt colors. Defaults to current colors.

For CoreXY designs, it's useful to be able to show the top and bottom belts in different colors. Also, it is possible to purchase white timing belts.