### PR TITLE
Add optional visible thread to studding

### DIFF
--- a/vitamins/rod.scad
+++ b/vitamins/rod.scad
@@ -21,6 +21,7 @@
 //! Steel rods and studding with chamfered ends.
 //
 include <../core.scad>
+include <springs.scad>
 
 rod_colour = grey80;
 studding_colour = grey70;
@@ -37,14 +38,20 @@ module rod(d , l) { //! Draw a smooth rod with specified length and diameter
         }
 }
 
-module studding(d , l) { //! Draw a threaded rod with specified length and diameter
+module studding(d , l, pitch = 0) { //! Draw a threaded rod with specified length, diameter and thread pitch. Thread not drawn if pitch is zero.
     vitamin(str("studding(", d, ", ", l,"): Threaded rod M", d, " x ", l, "mm"));
 
+    guage = pitch * 0.75;
+    if (pitch) {
+        turnCount = l/pitch;
+        thread  =  ["thread", d, guage, l, turnCount,  1, false, 0, studding_colour];
+        translate_z(-l/2) comp_spring(thread, vitamin = false);
+    }
     chamfer = d / 20;
     color(studding_colour)
         hull() {
-            cylinder(d = d, h = l - 2 * chamfer, center = true);
+            cylinder(d = d-guage/2, h = l - 2 * chamfer, center = true);
 
-            cylinder(d = d - 2 * chamfer, h = l, center = true);
+            cylinder(d = d-guage/2 - 2 * chamfer, h = l, center = true);
         }
 }

--- a/vitamins/spring.scad
+++ b/vitamins/spring.scad
@@ -64,18 +64,19 @@ function comp_spring(type, l = 0) = //! Calculate the mesh for spring
         profile = circle_points(wire_d / 2 - eps, $fn = 16)
        ) concat(type, [concat(sweep(path, profile), [l])]);
 
-module comp_spring(type, l = 0) { //! Draw specified spring, l can be set to specify the compressed length.
+module comp_spring(type, l = 0, vitamin = true) { //! Draw specified spring, l can be set to specify the compressed length.
     length = spring_length(type);
     closed = spring_closed(type);
     od = spring_od(type);
     od2 = spring_od2(type);
     gauge = spring_gauge(type);
     ground = spring_ground(type);
-    vitamin(str("comp_spring(", type[0], arg(l, 0),
-                "): Spring ", od, od != od2 ? str(" - ", od2, "mm spiral") : "mm", " OD, ", gauge, "mm gauge x ",
-                length, "mm long, ",
-                closed ? "closed" : "open",
-                ground ? " ground" : "", " end" ));
+    if (vitamin)
+        vitamin(str("comp_spring(", type[0], arg(l, 0),
+                    "): Spring ", od, od != od2 ? str(" - ", od2, "mm spiral") : "mm", " OD, ", gauge, "mm gauge x ",
+                    length, "mm long, ",
+                    closed ? "closed" : "open",
+                    ground ? " ground" : "", " end" ));
 
     mesh = len(type) > 9 ? spring_mesh(type) : spring_mesh(comp_spring(type, l));
     assert(l == mesh[2], "can't change the length of a pre-generated spring");


### PR DESCRIPTION
OK, this one is a bit quick and dirty. However it was cheap to implement, costs nothing if not used and adds a reasonable visible thread to a lead screw. Try

`studding(8,100,2);`

to see if you like it.

I haven't looked at the spring code in any detail, but I imagine far fewer fragments could be used when using a spring as a thread. This would improve performance without really detracting from the visual effect.