### PR TITLE
Added leadscrew. Used in stepper motors with long shaft.

### DIFF
--- a/tests/rod.scad
+++ b/tests/rod.scad
@@ -30,6 +30,10 @@ module rods()
 
         translate([0, 30])
             studding(bearing_rod_dia(linear_bearings[$i]), 80);
+
+        if(bearing_rod_dia(linear_bearings[$i]) >=6)
+            translate([0, 60])
+                leadscrew(bearing_rod_dia(linear_bearings[$i]), 80);
     }
 
 if($preview)

--- a/vitamins/rod.scad
+++ b/vitamins/rod.scad
@@ -21,9 +21,11 @@
 //! Steel rods and studding with chamfered ends.
 //
 include <../core.scad>
+use <../utils/sweep.scad>
 
 rod_colour = grey80;
 studding_colour = grey70;
+leadscrew_colour = grey70;
 
 module rod(d , l) { //! Draw a smooth rod with specified length and diameter
     vitamin(str("rod(", d, ", ", l, "): Smooth rod ", d, "mm x ", l, "mm"));
@@ -48,3 +50,40 @@ module studding(d , l) { //! Draw a threaded rod with specified length and diame
             cylinder(d = d - 2 * chamfer, h = l, center = true);
         }
 }
+
+module leadscrew(d, l, p) {//! Draw a leadscrew with the specified length, diameter and pitch
+    assert(d >= 4, "Leadscrew diameter must be >= 4");
+    diameter = d;
+    length = l;
+    pitch = p ? p : d > 10 ? 3 : 2;
+    color(leadscrew_colour)
+        translate_z(-length / 2 + pitch/4) { // additional pitch/4 elevation so thread does not protrude from bottom of rod
+            minorDiameter = diameter <= 6 ? diameter - 1 : diameter <= 10 ? diameter - pitch - 0.5 : diameter - pitch - 0.75;
+            // set up a square profile for the thread
+            a = max(diameter - minorDiameter, 1) / 2;
+            r = (diameter + minorDiameter + pitch) / 4;
+            profile =[[-pitch/4, -(diameter /2 - a)/2, 0], [pitch /4 , -(diameter /2 - a)/2, 0], [pitch / 4, (diameter /2 - r)/2, 0], [-pitch/4, (diameter / 2 - r)/2, 0]];
+
+            // create a spiral that is one turn of the thread, with one segment of overlap
+            count = ceil(max(min(360 / $fa, d*PI / $fs)/2, 5));
+            step = 360 / count;
+            spiral = [for(i = [0 : step : 360 + step]) [r * sin(i), -r * cos(i), i * pitch / 360]];
+
+            // do as many full turns as will fully fit in the length
+            turnCount = floor((length - pitch / 2) / pitch);
+            for(i = [0 : turnCount - 1])
+                translate_z(i * pitch) {
+                    sweep(spiral, profile, loop = false, twist = 30);
+                }
+
+            // add a partial turn at the end
+            end = ((length-pitch/2) - turnCount * pitch) / pitch * 360 - 20;
+            if(end > 20) {
+                spiralTop = [for(i = [0 : step : end]) [r * sin(i), -r*cos(i), i * pitch /360]];
+                translate_z(turnCount * pitch)
+                    sweep(spiralTop, profile, loop = false, twist = 30 * end / 360);
+            }
+            translate_z(-pitch/4) cylinder(d = minorDiameter, h = length);
+        }
+}
+

--- a/vitamins/stepper_motor.scad
+++ b/vitamins/stepper_motor.scad
@@ -24,6 +24,7 @@ include <../core.scad>
 
 include <screws.scad>
 use <washer.scad>
+use <rod.scad>
 include <ring_terminals.scad>
 use <../utils/tube.scad>
 
@@ -88,9 +89,13 @@ module NEMA(type) { //! Draw specified NEMA stepper motor
                         }
         }
 
-        color(NEMA_shaft_length(type) > 50 ? "silver" : stepper_cap_colour)
-            translate_z(-5)
-                cylinder(r = shaft_rad, h = NEMA_shaft_length(type) + 5);  // shaft
+        if (NEMA_shaft_length(type) > 50 )
+            translate_z(-5 + NEMA_shaft_length(type) / 2)
+                leadscrew(d = shaft_rad * 2, l = NEMA_shaft_length(type) + 5, p = 2);
+        else
+            color(stepper_cap_colour)
+                translate_z(-5)
+                    cylinder(r = shaft_rad, h = NEMA_shaft_length(type) + 5);  // shaft
 
         translate([0, side / 2, -length + cap / 2])
             rotate([90, 0, 0])


### PR DESCRIPTION
This time I've done a proper implementation which is reasonably performant. The thread is square-cut as on leadscrews. Here's an example of how it looks:

![Screenshot (5)](https://user-images.githubusercontent.com/194586/72551297-7eac0100-388c-11ea-922a-e0f17f048635.png)
