### PR TITLE
Added scad/printed to stl search path.

### DIFF
--- a/scripts/exports.py
+++ b/scripts/exports.py
@@ -85,7 +85,7 @@ def make_parts(target, part_type, parts = None):
     #
     lib_dir = os.environ['OPENSCADPATH'] + '/NopSCADlib/printed'
     module_suffix = '_dxf' if part_type == 'svg' else '_' + part_type
-    for dir in [source_dir, lib_dir]:
+    for dir in [source_dir, source_dir + '/printed', lib_dir]:
         for filename in os.listdir(dir):
             if filename[-5:] == ".scad":
                 #

--- a/scripts/views.py
+++ b/scripts/views.py
@@ -124,7 +124,7 @@ def views(target, do_assemblies = None):
     #
     main_blurb = None
     lib_dir = os.environ['OPENSCADPATH'] + '/NopSCADlib/printed'
-    for dir in [source_dir, lib_dir]:
+    for dir in [source_dir, source_dir + '/printed', lib_dir]:
         for filename in os.listdir(dir):
             if filename.endswith('.scad'):
                 #


### PR DESCRIPTION
Allows better organisation for a largish build. Main assembly and sub assemblies can be in `scad`, printed parts in `scad/printed` and vitamins in `scad/vitamins`.