### PR TITLE
Improved tnut positioning and hammer nut handling.

### DIFF
--- a/tests/nuts.scad
+++ b/tests/nuts.scad
@@ -58,10 +58,10 @@ module nuts() {
 
         translate([0, 80]) {
             if(n == M3_nut)
-                hammer_nut(M3_hammer_nut);
+                sliding_t_nut(M3_hammer_nut);
 
             if(n == M4_nut)
-                hammer_nut(M4_hammer_nut);
+                sliding_t_nut(M4_hammer_nut);
        }
     }
 }

--- a/vitamins/nut.scad
+++ b/vitamins/nut.scad
@@ -132,29 +132,18 @@ module wingnut(type) { //! Draw a wingnut
 }
 
 module sliding_t_nut(type) {
-    vitamin(str("sliding_t_nut(", type[0], "): Nut M", nut_size(type), " sliding T"));
+    hammerNut = type[11];
+    vitamin(str("sliding_t_nut(", type[0], "): Nut M", nut_size(type), hammerNut ? " hammer" : " sliding T"));
 
-    size = [type[7], type[2], nut_thickness(type, true)];
+    size = [type[7], type[2], nut_thickness(type)];
     tabSizeY1 = type[8];
     tabSizeY2 = type[9];
-    tabSizeZ = nut_thickness(type);
+    tabSizeZ = type[10];
     holeRadius  = nut_size(type) / 2;
 
     color(grey80)
-        extrusionSlidingNut(size, tabSizeY1, tabSizeY2, tabSizeZ, holeRadius);
-}
-
-module hammer_nut(type) {
-    vitamin(str("hammer_nut(", type[0], "): Nut M", nut_size(type), " hammer"));
-
-    size = [type[7], type[2], nut_thickness(type, true)];
-    tabSizeY1 = type[8];
-    tabSizeY2 = type[9];
-    tabSizeZ = nut_thickness(type);
-    holeRadius  = nut_size(type) / 2;
-
-    color(grey80)
-        extrusionSlidingNut(size, tabSizeY1, tabSizeY2, tabSizeZ, holeRadius, 0, hammerNut = true);
+        vflip()
+            extrusionSlidingNut(size, tabSizeY1, tabSizeY2, tabSizeZ, holeRadius, 0, hammerNut);
 }
 
 module extrusionSlidingNut(size, tabSizeY1, tabSizeY2, tabSizeZ, holeRadius, holeOffset = 0, hammerNut = false) {

--- a/vitamins/nut.scad
+++ b/vitamins/nut.scad
@@ -142,8 +142,7 @@ module sliding_t_nut(type) {
     holeRadius  = nut_size(type) / 2;
 
     color(grey80)
-        vflip()
-            extrusionSlidingNut(size, tabSizeY1, tabSizeY2, tabSizeZ, holeRadius, 0, hammerNut);
+        extrusionSlidingNut(size, tabSizeY1, tabSizeY2, tabSizeZ, holeRadius, 0, hammerNut);
 }
 
 module extrusionSlidingNut(size, tabSizeY1, tabSizeY2, tabSizeZ, holeRadius, holeOffset = 0, hammerNut = false) {

--- a/vitamins/nuts.scad
+++ b/vitamins/nuts.scad
@@ -51,12 +51,12 @@ toggle_nut  =      ["toggle_nut",       6.1, 9.2, 1.5, 1.5,  M6_washer,     1.5]
 
 M4_wingnut  =      ["M4_wingnut",       4,  10,   3.75,8,    M4_washer,     0, 22, 10, 6, 3];
 
-//                                                                              sx  ty1 ty2
-M3_sliding_t_nut = ["M3_sliding_t_nut", 3,   6,   3.0, 4.0,  false,         0,  10,  10,  6];
-M4_sliding_t_nut = ["M4_sliding_t_nut", 4,   6,   3.25,4.5,  false,         0,  11,  10,  6];
-M5_sliding_t_nut = ["M5_sliding_t_nut", 5,   6,   3.25,4.5,  false,         0,  11,  10,  7];
-M3_hammer_nut =    ["M3_hammer_nut",    3,   6,   2.75,4.0,  false,         0, 5.5,  10,  6];
-M4_hammer_nut =    ["M4_hammer_nut",    4,   6,   3.25,4.5,  false,         0, 5.5,  10,  6];
+//                                                                              sx  ty1 ty2   tz  hammer
+M3_sliding_t_nut = ["M3_sliding_t_nut", 3,   6,   4.0, 0,    false,         0,  10,  10,  6, 3.0,  false];
+M4_sliding_t_nut = ["M4_sliding_t_nut", 4,   6,   4.5, 0,    false,         0,  11,  10,  6, 3.25, false];
+M5_sliding_t_nut = ["M5_sliding_t_nut", 5,   6,   4.5, 0,    false,         0,  11,  10,  7, 3.25, false];
+M3_hammer_nut =    ["M3_hammer_nut",    3,   6,   4.0, 0,    false,         0, 5.5,  10,  6, 2.75, true];
+M4_hammer_nut =    ["M4_hammer_nut",    4,   6,   4.5, 0,    false,         0, 5.5,  10,  6, 3.25, true];
 
 nuts = [M2_nut, M2p5_nut, M3_nut, M4_nut, M5_nut, M6_nut, M8_nut];
 

--- a/vitamins/sk_bracket.scad
+++ b/vitamins/sk_bracket.scad
@@ -116,10 +116,9 @@ module sk_bracket_assembly(type, part_thickness = 2, screw_type = M5_cap_screw, 
     sk_bracket_hole_positions(type) {
         screw_and_washer(screw_type, screw_length);
         translate_z(-nut_offset)
-            vflip()
-                if(!nut_washer_type)
-                    sliding_t_nut(nut_type);
-                else
-                    nut_and_washer(nut_type);
+            if(nut_washer_type)
+                nut_and_washer(nut_type);
+            else
+                sliding_t_nut(nut_type);
     }
 }

--- a/vitamins/sk_bracket.scad
+++ b/vitamins/sk_bracket.scad
@@ -116,9 +116,10 @@ module sk_bracket_assembly(type, part_thickness = 2, screw_type = M5_cap_screw, 
     sk_bracket_hole_positions(type) {
         screw_and_washer(screw_type, screw_length);
         translate_z(-nut_offset)
-            if(nut_washer_type)
-                nut_and_washer(nut_type);
-            else
-                sliding_t_nut(nut_type);
+            vflip()
+                if(nut_washer_type)
+                    nut_and_washer(nut_type);
+                else
+                    sliding_t_nut(nut_type);
     }
 }


### PR DESCRIPTION
I think this is the way to handle the tnut positioning. tnut is drawn in correct orientation and offset for screw, no faking its thickness or using nyloc functionality.

Also hammer nuts are drawn using `sliding_t_nut` so that substituting hammer nuts for tnuts is facilitated.