### PR TITLE
Fix handling of (Windows) paths with spaces

### DIFF
--- a/scripts/deps.py
+++ b/scripts/deps.py
@@ -33,7 +33,7 @@ def read_deps(dname):
     deps = []
     for line in lines:
         if line.startswith('\t'):
-            dep = line[1 : -1].rstrip(' \\')
+            dep = line[1 : -1].rstrip(' \\').replace('\\ ', ' ')
             if not os.path.basename(dep) in ['stl.scad', 'dxf.scad', 'svf.scad', 'png.scad', 'target.scad']:
                 deps.append(dep)
     return deps


### PR DESCRIPTION
I was getting errors when processing paths like `C:\Users\ftwie\Documents\Fisher Price CNC\scad` - the script just wouldn't pick up directories where the path had a space character because it didn't properly unescape the `\ ` sequence. This patch fixes that. Only tested with Windows paths.