### PR TITLE
nut_radius is needed for screw_boss_diameter

### DIFF
--- a/vitamins/screw.scad
+++ b/vitamins/screw.scad
@@ -23,6 +23,7 @@
 include <../utils/core/core.scad>
 
 use <washer.scad>
+use <nut.scad>
 use <../utils/rounded_cylinder.scad>
 use <../utils/thread.scad>
 include <inserts.scad>


### PR DESCRIPTION
using `include <NopSCADlib/lib.scad>` in main file fails in `screw_boss_diameter`:
`WARNING: Ignoring unknown function 'nut_radius', in file ../../../sw/OpenSCAD/libraries/NopSCADlib/vitamins/screw.scad, line 41.`

Maybe my library usage is wrong, I did not investigate further ...