### PR TITLE
Fixed rounding error in hangin_hole assert.

### DIFF
--- a/utils/hanging_hole.scad
+++ b/utils/hanging_hole.scad
@@ -35,7 +35,7 @@ module hanging_hole(z, ir, h = 100, h2 = 100) { //! Hole radius ```ir``` hanging
                         poly_cylinder(r - eps, h - layer_height);
             }
     }
-    assert(z % layer_height == 0, str(z));
+    assert(z - layer_height * floor(z / layer_height) < eps, str(z));
     infill_angle = z % (2 * layer_height) ? -45 : 45;
     below = min(z + eps, h2);
     big = 1000;


### PR DESCRIPTION
`hanging_hole` asserts that the `z` value is divisible by `layer_height`. However it uses the `%` operator for division, and the `%` operator is an integer operation and so is subject to rounding errors when applied to decimal numbers that are not exact binary fractions. So, for example `18 % 0.05` equals 0.05, and not zero as one would expect. I haven't checked, but I expect layer heights of 0.1 and 0.2 will also be hit by this. I personally was hit by using a layer height of 1/3mm (0.33333333). This pull request uses floating point arithmetic to calculate the modulus. 