### PR TITLE
Added rotating polycylinder.

### DIFF
--- a/utils/core/polyholes.scad
+++ b/utils/core/polyholes.scad
@@ -32,9 +32,19 @@ module poly_circle(r, sides = 0) { //! Make a circle adjusted to print the corre
     circle(r = corrected_radius(r,n), $fn = n);
 }
 
-module poly_cylinder(r, h, center = false, sides = 0, chamfer = false) {//! Make a cylinder adjusted to print the correct size
-    extrude_if(h, center)
-        poly_circle(r, sides);
+module poly_cylinder(r, h, center = false, sides = 0, chamfer = false, rotating = false) {//! Make a cylinder adjusted to print the correct size
+    if (rotating) {
+        sides = sides ? sides : sides(r);
+        layers = floor(h / layer_height);
+        lh = layer_height + eps;
+        for(i = [0 : layers - 1])
+            translate_z(i * layer_height + (center ? -h / 2 : 0))
+                rotate(i * 180 / layers)
+                    poly_cylinder(r = r, h = lh, center = false, sides = sides, rotating = false);
+    } else {
+        extrude_if(h, center)
+            poly_circle(r, sides);
+    }
 
     if(h && chamfer)
         poly_cylinder(r + layer_height, center ? layer_height * 2 : layer_height, center, sides = sides ? sides : sides(r));


### PR DESCRIPTION
Here's the rotating polyhole. The image shows the rotating polyhole and the corresponding polyhole at a radius of 'M3_tap_radius'. The second column are the polyholes cut out of a cuboid, and the third column shows the top view of the cuboid. From above, the rotating polyhole looks almost perfectly round.

![rotating_polyholes](https://user-images.githubusercontent.com/194586/102482412-0b41df00-405b-11eb-9cbc-df4ad21421d1.png)
