### PR TITLE
Added rounded_rectangles in the XZ and YZ planes.

### DIFF
--- a/tests/rounded_rectangle.scad
+++ b/tests/rounded_rectangle.scad
@@ -25,6 +25,12 @@ module rounded_rectangles() {
 
     translate([40, 0])
         rounded_rectangle([30, 20, 10], 3);
+
+    translate([80, 0])
+        rounded_rectangle_xz([30, 20, 10], 3);
+
+    translate([120, 0])
+        rounded_rectangle_yz([30, 20, 10], 3);
 }
 
 rounded_rectangles();

--- a/utils/core/rounded_rectangle.scad
+++ b/utils/core/rounded_rectangle.scad
@@ -28,6 +28,21 @@ module rounded_square(size, r, center = true) //! Like ```square()``` but with w
 
 module rounded_rectangle(size, r, center = true, xy_center = true) //! Like ```cube()``` but corners rounded in XY plane and separate centre options for xy and z.
 {
-    linear_extrude(size[2], center = center)
-        rounded_square([size[0], size[1]], r, xy_center);
+    linear_extrude(size.z, center = center)
+        rounded_square([size.x, size.y], r, xy_center);
 }
+
+module rounded_rectangle_xz(size, r, center = true, xy_center = true) //! Like ```cube()``` but corners rounded in XZ plane and separate centre options for xy and z.
+{
+    translate([xy_center ? 0 : size.x / 2, xy_center ? 0 : size.y / 2, center ? 0 : size.z / 2])
+        rotate([90, 0, 0])
+            rounded_rectangle([size.x, size.z, size.y], r, center = true, xy_center = true);
+}
+
+module rounded_rectangle_yz(size, r, center = true, xy_center = true) //! Like ```cube()``` but corners rounded in YX plane and separate centre options for xy and z.
+{
+    translate([xy_center ? 0 : size.x / 2, xy_center ? 0 : size.y / 2, center ? 0 : size.z / 2])
+        rotate([90, 0, 90])
+            rounded_rectangle([size.y, size.z, size.x], r, center = true, xy_center = true);
+}
+


### PR DESCRIPTION
Add `rounded_rectangle_xz` and `rounded_rectangle_yz` modules that round in the respective planes.

Actually I think they should be called `rounded_cube_xz` and `rounded_cube_yz` and we should add `rounded_cube_xy`, while retaining the original `rounded_rectangle` module so as not to break old code.

I can see the original argument for not calling `rounded_rectangle` `rounded_cube` since it was not rounded on all 3 axes, but when there are three variants that argument no longer holds up.