### PR TITLE
Changed linear rails to use a v-slot rather than a square slot.

### DIFF
--- a/vitamins/rails.scad
+++ b/vitamins/rails.scad
@@ -32,14 +32,14 @@ SSR15_carriage = [ 40.3, 23.3, 34, 24, 4.5, 0,  26, M4_cap_screw ];
 // Rails
 //
 //
-//                Wr  Hr   E    P   D    d    h
-MGN5 = [ "MGN5",  5,  3.6, 5,   15, 3.6, 2.4, 0.8, M2_cs_cap_screw, MGN5_carriage, M2_cs_cap_screw ]; // Screw holes too small for M2 heads
-MGN7 = [ "MGN7",  7,  5,   5,   15, 4.3, 2.4, 2.6, M2_cap_screw,    MGN7_carriage, M2_cs_cap_screw ];
-MGN9 = [ "MGN9",  9,  6,   7.5, 20, 6.0, 3.5, 3.5, M3_cap_screw,    MGN9_carriage, M3_cs_cap_screw ];
-MGN12= [ "MGN12", 12, 8,   10,  25, 6.0, 3.5, 4.5, M3_cap_screw,   MGN12_carriage, M3_cs_cap_screw ];
-MGN12H=[ "MGN12H",12, 8,   10,  25, 6.0, 3.5, 4.5, M3_cap_screw,   MGN12H_carriage,M3_cs_cap_screw ];
-MGN15= [ "MGN15", 15, 10,  10,  40, 6.0, 3.5, 5.0, M3_cap_screw,   MGN15_carriage, M3_cs_cap_screw ];
-SSR15= [ "SSR15", 15, 12.5,10,  60, 7.5, 4.5, 5.3, M4_cap_screw,   SSR15_carriage, M4_cs_cap_screw ];
+//                Wr  Hr   E    P   D    d    h                                                      go    gw
+MGN5 = [ "MGN5",  5,  3.6, 5,   15, 3.6, 2.4, 0.8, M2_cs_cap_screw, MGN5_carriage, M2_cs_cap_screw,  1,    1 ]; // Screw holes too small for M2 heads
+MGN7 = [ "MGN7",  7,  5,   5,   15, 4.3, 2.4, 2.6, M2_cap_screw,    MGN7_carriage, M2_cs_cap_screw,  1.5,  1.5 ];
+MGN9 = [ "MGN9",  9,  6,   7.5, 20, 6.0, 3.5, 3.5, M3_cap_screw,    MGN9_carriage, M3_cs_cap_screw,  1.5,  1.5 ];
+MGN12= [ "MGN12", 12, 8,   10,  25, 6.0, 3.5, 4.5, M3_cap_screw,   MGN12_carriage, M3_cs_cap_screw,  2.25, 2.75 ];
+MGN12H=[ "MGN12H",12, 8,   10,  25, 6.0, 3.5, 4.5, M3_cap_screw,   MGN12H_carriage,M3_cs_cap_screw,  2.25, 2.75];
+MGN15= [ "MGN15", 15, 10,  10,  40, 6.0, 3.5, 5.0, M3_cap_screw,   MGN15_carriage, M3_cs_cap_screw,  2.5,  2.75 ];
+SSR15= [ "SSR15", 15, 12.5,10,  60, 7.5, 4.5, 5.3, M4_cap_screw,   SSR15_carriage, M4_cs_cap_screw,  2.5,  2.75 ];
 
 rails = [MGN5, MGN7, MGN9, MGN12, MGN12H, MGN15, SSR15];
 


### PR DESCRIPTION
This looks a lot better, and the slot is more visible.

It also means that linear rails are now printable, and even usable

There are a number of reasons you might want to print a linear rail

1. to build a prototype while waiting for parts to arrive
2. for a cheap or not often used project where high precision is not required
3. to follow the original RepRap philosophy of maximising printed parts

(Note that currently the dimensions have not been tuned or tested for use as printed parts, however they are fine for just drawing the parts. The video shows a MGN12 carriage being used on a printed rail - there is still a bit of play but I am confident that can be reduced to make the printed rail genuinely useful in certain projects).

https://user-images.githubusercontent.com/194586/104091738-3d6be880-5277-11eb-99fd-861702f4caa7.MOV


