### PR TITLE
Made C version of linear rails and carriages explicit.

### DIFF
--- a/tests/rails.scad
+++ b/tests/rails.scad
@@ -26,15 +26,16 @@ sheet = 3;
 pos = 1; //[-1 : 0.1 : 1]
 
 module rails()
-    layout([for(l = rails) carriage_width(rail_carriage(l))], 20)
+    layout([for(l = carriages) carriage_width(l)], 20)
         rotate(-90) {
-            rail = rails[$i];
+            carriage = carriages[$i];
+            rail = carriage_rail(carriage);
             length = 200;
             screw = rail_screw(rail);
             nut = screw_nut(screw);
             washer = screw_washer(screw);
 
-            rail_assembly(rail, length, pos * rail_travel(rail, length) / 2, $i<2 ? grey(20) : "green", $i<2 ? grey(20) : "red");
+            rail_assembly(carriage, length, pos * carriage_travel(carriage, length) / 2, $i<2 ? grey(20) : "green", $i<2 ? grey(20) : "red");
 
             rail_screws(rail, length, sheet + nut_thickness(nut, true) + washer_thickness(washer));
 

--- a/vitamins/rail.scad
+++ b/vitamins/rail.scad
@@ -31,13 +31,11 @@ function rail_bore(type)       = type[5];   //! Counter bore diameter for screw 
 function rail_hole(type)       = type[6];   //! Screw hole diameter
 function rail_bore_depth(type) = type[7];   //! Counter bore depth
 function rail_screw(type)      = type[8];   //! Screw type
-function rail_carriage(type)   = type[9];   //! Carriage type
-function rail_end_screw(type)  = type[10];  //! Screw used for ends only (Countersink used for better location)
-function rail_groove_offset(type)=type[11]; //! Offset of centre of groove from top of rail
-function rail_groove_width(type)=type[12];  //! Groove width
+function rail_end_screw(type)  = type[9];   //! Screw used for ends only (Countersink used for better location)
+function rail_groove_offset(type)=type[10]; //! Offset of centre of groove from top of rail
+function rail_groove_width(type)=type[11];  //! Groove width
 
 function rail_screw_height(type, screw) = rail_height(type) - rail_bore_depth(type) + screw_head_depth(screw, rail_hole(type)); //! Position screw taking into account countersink into counterbored hole
-function rail_travel(type, length) = length - carriage_length(rail_carriage(type)); //! How far the carriage can travel
 
 function carriage_length(type)       = type[0]; //! Overall length
 function carriage_block_length(type) = type[1]; //! Length of the metal part
@@ -48,7 +46,9 @@ function carriage_clearance(type)    = type[4]; //! Gap under the carriage
 function carriage_pitch_x(type)      = type[5]; //! Screw hole x pitch
 function carriage_pitch_y(type)      = type[6]; //! Screw hole y pitch
 function carriage_screw(type)        = type[7]; //! Carriage screw type
+function carriage_rail(type)         = type[8]; //! Rail type
 function carriage_screw_depth(type)  = 2 * screw_radius(carriage_screw(type)); //! Carriage thread depth
+function carriage_travel(type, rail_length) = rail_length - carriage_length(type); //! How far the carriage can travel on a given length rail
 
 function rail_holes(type, length) = //! Number of holes in a rail given its `length`
     floor((length - 2 * rail_end(type)) / rail_pitch(type)) + 1;
@@ -73,7 +73,7 @@ module carriage_hole_positions(type) { //! Position children over screw holes
                 children();
 }
 
-module carriage(type, rail, end_colour = grey(20), wiper_colour = grey(20)) { //! Draw the specified carriage
+module carriage(type, end_colour = grey(20), wiper_colour = grey(20)) { //! Draw the specified carriage
     total_l = carriage_length(type);
     block_l = carriage_block_length(type);
     block_w = carriage_width(type);
@@ -85,9 +85,9 @@ module carriage(type, rail, end_colour = grey(20), wiper_colour = grey(20)) { //
     screw_depth = carriage_screw_depth(type);
 
     module cutout() {
-        w = rail_width(rail) + 0.4;
+        w = rail_width(carriage_rail(type)) + 0.4;
         translate([-w / 2, 0])
-            square([w , rail_height(rail) + 0.2]);
+            square([w , rail_height(carriage_rail(type)) + 0.2]);
     }
 
     color(grey(90)) {
@@ -179,11 +179,11 @@ module rail(type, length, colour = grey(90), use_polycircles = false) { //! Draw
     }
 }
 
-module rail_assembly(type, length, pos, carriage_end_colour = grey(20), carriage_wiper_colour = grey(20)) { //! Rail and carriage assembly
-    rail(type, length);
+module rail_assembly(carriage, length, pos, carriage_end_colour = grey(20), carriage_wiper_colour = grey(20)) { //! Rail and carriage assembly
+    rail(carriage_rail(carriage), length);
 
     translate([pos, 0])
-        carriage(rail_carriage(type), type,  carriage_end_colour, carriage_wiper_colour);
+        carriage(carriage, carriage_end_colour, carriage_wiper_colour);
 }
 
 module rail_screws(type, length, thickness, screws = 100, index_screws = undef) { //! Place screws in the rail

--- a/vitamins/rails.scad
+++ b/vitamins/rails.scad
@@ -18,29 +18,28 @@
 //
 
 //
-// Carriages
-//
-//                 L     L1    W   H   H1   C   B
-MGN5_carriage  = [ 16,   9.6,  12, 6,  1.5, 0,  8 , M2_cap_screw ];
-MGN7C_carriage = [ 23,   14.3, 17, 8,  1.5, 8,  12, M2_cap_screw ];
-MGN9C_carriage = [ 29.7, 20.8, 20, 10, 2,   10, 15, M3_cap_screw ];
-MGN12C_carriage= [ 34.7, 21.7, 27, 13, 3,   15, 20, M3_cap_screw ];
-MGN12H_carriage= [ 45.4, 32.4, 27, 13, 3,   20, 20, M3_cap_screw ];
-MGN15C_carriage= [ 43.3, 27.7, 32, 16, 4,   20, 25, M3_cap_screw ];
-SSR15_carriage = [ 40.3, 23.3, 34, 24, 4.5, 0,  26, M4_cap_screw ];
-//
 // Rails
 //
+//                Wr  Hr    E     P   D    d    h                                       go    gw
+MGN5 = [ "MGN5",   5,  3.6,  5,   15, 3.6, 2.4, 0.8, M2_cs_cap_screw, M2_cs_cap_screw,  1,    1 ]; // Screw holes too small for M2 heads
+MGN7 = [ "MGN7",   7,  5,    5,   15, 4.3, 2.4, 2.6, M2_cap_screw,    M2_cs_cap_screw,  1.5,  1.5 ];
+MGN9 = [ "MGN9",   9,  6,    7.5, 20, 6.0, 3.5, 3.5, M3_cap_screw,    M3_cs_cap_screw,  1.5,  1.5 ];
+MGN12 =[ "MGN12", 12,  8,   10,   25, 6.0, 3.5, 4.5, M3_cap_screw,    M3_cs_cap_screw,  2.25, 2.75];
+MGN15 =[ "MGN15", 15, 10,   10,   40, 6.0, 3.5, 5.0, M3_cap_screw,    M3_cs_cap_screw,  2.5,  2.75 ];
+SSR15= [ "SSR15", 15, 12.5, 10,   60, 7.5, 4.5, 5.3, M4_cap_screw,    M4_cs_cap_screw,  2.5,  2.75 ];
 //
-//                Wr  Hr   E    P   D    d    h                                                      go    gw
-MGN5 = [ "MGN5",  5,  3.6, 5,   15, 3.6, 2.4, 0.8, M2_cs_cap_screw, MGN5_carriage, M2_cs_cap_screw,  1,    1 ]; // Screw holes too small for M2 heads
-MGN7C= [ "MGN7C", 7,  5,   5,   15, 4.3, 2.4, 2.6, M2_cap_screw,   MGN7C_carriage, M2_cs_cap_screw,  1.5,  1.5 ];
-MGN9C= [ "MGN9C", 9,  6,   7.5, 20, 6.0, 3.5, 3.5, M3_cap_screw,   MGN9C_carriage, M3_cs_cap_screw,  1.5,  1.5 ];
-MGN12C=[ "MGN12C",12, 8,   10,  25, 6.0, 3.5, 4.5, M3_cap_screw,   MGN12C_carriage,M3_cs_cap_screw,  2.25, 2.75 ];
-MGN12H=[ "MGN12H",12, 8,   10,  25, 6.0, 3.5, 4.5, M3_cap_screw,   MGN12H_carriage,M3_cs_cap_screw,  2.25, 2.75];
-MGN15C=[ "MGN15C",15, 10,  10,  40, 6.0, 3.5, 5.0, M3_cap_screw,   MGN15C_carriage,M3_cs_cap_screw,  2.5,  2.75 ];
-SSR15= [ "SSR15", 15, 12.5,10,  60, 7.5, 4.5, 5.3, M4_cap_screw,   SSR15_carriage, M4_cs_cap_screw,  2.5,  2.75 ];
+// Carriages
+//
+//                  L     L1    W   H   H1   C   B
+MGN5_carriage   = [ 16,    9.6, 12,  6, 1.5, 0,   8, M2_cap_screw, MGN5 ];
+MGN7C_carriage  = [ 23,   14.3, 17,  8, 1.5, 8,  12, M2_cap_screw, MGN7 ];
+MGN9C_carriage  = [ 29.7, 20.8, 20, 10, 2,  10,  15, M3_cap_screw, MGN9 ];
+MGN12C_carriage = [ 34.7, 21.7, 27, 13, 3,  15,  20, M3_cap_screw, MGN12 ];
+MGN12H_carriage = [ 45.4, 32.4, 27, 13, 3,  20,  20, M3_cap_screw, MGN12 ];
+MGN15C_carriage = [ 43.3, 27.7, 32, 16, 4,  20,  25, M3_cap_screw, MGN15 ];
+SSR15_carriage  = [ 40.3, 23.3, 34, 24, 4.5, 0,  26, M4_cap_screw, SSR15 ];
 
-rails = [MGN5, MGN7C, MGN9C, MGN12C, MGN12H, MGN15C, SSR15];
+
+carriages = [MGN5_carriage, MGN7C_carriage, MGN9C_carriage, MGN12C_carriage, MGN12H_carriage, MGN15C_carriage, SSR15_carriage];
 
 use <rail.scad>

--- a/vitamins/rails.scad
+++ b/vitamins/rails.scad
@@ -22,11 +22,11 @@
 //
 //                 L     L1    W   H   H1   C   B
 MGN5_carriage  = [ 16,   9.6,  12, 6,  1.5, 0,  8 , M2_cap_screw ];
-MGN7_carriage  = [ 23,   14.3, 17, 8,  1.5, 8,  12, M2_cap_screw ];
-MGN9_carriage  = [ 29.7, 20.8, 20, 10, 2,   10, 15, M3_cap_screw ];
-MGN12_carriage = [ 34.7, 21.7, 27, 13, 3,   15, 20, M3_cap_screw ];
+MGN7C_carriage = [ 23,   14.3, 17, 8,  1.5, 8,  12, M2_cap_screw ];
+MGN9C_carriage = [ 29.7, 20.8, 20, 10, 2,   10, 15, M3_cap_screw ];
+MGN12C_carriage= [ 34.7, 21.7, 27, 13, 3,   15, 20, M3_cap_screw ];
 MGN12H_carriage= [ 45.4, 32.4, 27, 13, 3,   20, 20, M3_cap_screw ];
-MGN15_carriage = [ 43.3, 27.7, 32, 16, 4,   20, 25, M3_cap_screw ];
+MGN15C_carriage= [ 43.3, 27.7, 32, 16, 4,   20, 25, M3_cap_screw ];
 SSR15_carriage = [ 40.3, 23.3, 34, 24, 4.5, 0,  26, M4_cap_screw ];
 //
 // Rails
@@ -34,13 +34,13 @@ SSR15_carriage = [ 40.3, 23.3, 34, 24, 4.5, 0,  26, M4_cap_screw ];
 //
 //                Wr  Hr   E    P   D    d    h                                                      go    gw
 MGN5 = [ "MGN5",  5,  3.6, 5,   15, 3.6, 2.4, 0.8, M2_cs_cap_screw, MGN5_carriage, M2_cs_cap_screw,  1,    1 ]; // Screw holes too small for M2 heads
-MGN7 = [ "MGN7",  7,  5,   5,   15, 4.3, 2.4, 2.6, M2_cap_screw,    MGN7_carriage, M2_cs_cap_screw,  1.5,  1.5 ];
-MGN9 = [ "MGN9",  9,  6,   7.5, 20, 6.0, 3.5, 3.5, M3_cap_screw,    MGN9_carriage, M3_cs_cap_screw,  1.5,  1.5 ];
-MGN12= [ "MGN12", 12, 8,   10,  25, 6.0, 3.5, 4.5, M3_cap_screw,   MGN12_carriage, M3_cs_cap_screw,  2.25, 2.75 ];
+MGN7C= [ "MGN7C", 7,  5,   5,   15, 4.3, 2.4, 2.6, M2_cap_screw,   MGN7C_carriage, M2_cs_cap_screw,  1.5,  1.5 ];
+MGN9C= [ "MGN9C", 9,  6,   7.5, 20, 6.0, 3.5, 3.5, M3_cap_screw,   MGN9C_carriage, M3_cs_cap_screw,  1.5,  1.5 ];
+MGN12C=[ "MGN12C",12, 8,   10,  25, 6.0, 3.5, 4.5, M3_cap_screw,   MGN12C_carriage,M3_cs_cap_screw,  2.25, 2.75 ];
 MGN12H=[ "MGN12H",12, 8,   10,  25, 6.0, 3.5, 4.5, M3_cap_screw,   MGN12H_carriage,M3_cs_cap_screw,  2.25, 2.75];
-MGN15= [ "MGN15", 15, 10,  10,  40, 6.0, 3.5, 5.0, M3_cap_screw,   MGN15_carriage, M3_cs_cap_screw,  2.5,  2.75 ];
+MGN15C=[ "MGN15C",15, 10,  10,  40, 6.0, 3.5, 5.0, M3_cap_screw,   MGN15C_carriage,M3_cs_cap_screw,  2.5,  2.75 ];
 SSR15= [ "SSR15", 15, 12.5,10,  60, 7.5, 4.5, 5.3, M4_cap_screw,   SSR15_carriage, M4_cs_cap_screw,  2.5,  2.75 ];
 
-rails = [MGN5, MGN7, MGN9, MGN12, MGN12H, MGN15, SSR15];
+rails = [MGN5, MGN7C, MGN9C, MGN12C, MGN12H, MGN15C, SSR15];
 
 use <rail.scad>


### PR DESCRIPTION
Renamed `MGN7 ` etc to `MGN7C` to make the variant of the rail and carriage explicit.

Without this rename you have to find a linear rail dimension chart to work out which version of the rail/carriage you are getting.