### PR TITLE
Rounded rectangles revisited

### DIFF
--- a/tests/rounded_rectangle.scad
+++ b/tests/rounded_rectangle.scad
@@ -27,10 +27,13 @@ module rounded_rectangles() {
         rounded_rectangle([30, 20, 10], 3);
 
     translate([80, 0])
-        rounded_rectangle_xz([30, 20, 10], 3);
+        rounded_cube_xy([30, 20, 10], 3);
 
     translate([120, 0])
-        rounded_rectangle_yz([30, 20, 10], 3);
+        rounded_cube_xz([30, 20, 10], 3);
+
+    translate([160, 0])
+        rounded_cube_yz([30, 20, 10], 3);
 }
 
 rounded_rectangles();

--- a/utils/core/rounded_rectangle.scad
+++ b/utils/core/rounded_rectangle.scad
@@ -22,32 +22,33 @@
 //
 module rounded_square(size, r, center = true) //! Like `square()` but with with rounded corners
 {
+    assert(r < min(size.x, size.y) / 2);
     $fn = r2sides4n(r);
     offset(r) offset(-r) square(size, center = center);
 }
 
 module rounded_rectangle(size, r, center = true, xy_center = true) //! Like `cube()` but corners rounded in XY plane and separate centre options for xy and z.
 {
-    linear_extrude(size.z, center = center)
+    extrude_if(size.z, center = center)
         rounded_square([size.x, size.y], r, xy_center);
 }
 
-module rounded_cube_xy(size, r, center = false, xy_center = false) //! Like `cube()` but corners rounded in XY plane and separate centre options for xy and z.
+module rounded_cube_xy(size, r = 0, xy_center = false, z_center = false) //! Like `cube()` but corners rounded in XY plane and separate centre options for xy and z.
 {
-    linear_extrude(size.z, center = center)
+    extrude_if(size.z, center = z_center)
         rounded_square([size.x, size.y], r, xy_center);
 }
 
-module rounded_cube_xz(size, r, center = false, xy_center = false) //! Like `cube()` but corners rounded in XZ plane and separate centre options for xy and z.
+module rounded_cube_xz(size, r = 0, xy_center = false, z_center = false) //! Like `cube()` but corners rounded in XZ plane and separate centre options for xy and z.
 {
-    translate([xy_center ? 0 : size.x / 2, xy_center ? 0 : size.y / 2, center ? 0 : size.z / 2])
+    translate([xy_center ? 0 : size.x / 2, xy_center ? 0 : size.y / 2, z_center ? 0 : size.z / 2])
         rotate([90, 0, 0])
-            rounded_cube_xy([size.x, size.z, size.y], r, center = true, xy_center = true);
+            rounded_cube_xy([size.x, size.z, size.y], r, xy_center = true, z_center = true);
 }
 
-module rounded_cube_yz(size, r, center = false, xy_center = false) //! Like `cube()` but corners rounded in YX plane and separate centre options for xy and z.
+module rounded_cube_yz(size, r = 0, xy_center = false, z_center = false) //! Like `cube()` but corners rounded in YX plane and separate centre options for xy and z.
 {
-    translate([xy_center ? 0 : size.x / 2, xy_center ? 0 : size.y / 2, center ? 0 : size.z / 2])
+    translate([xy_center ? 0 : size.x / 2, xy_center ? 0 : size.y / 2, z_center ? 0 : size.z / 2])
         rotate([90, 0, 90])
-            rounded_cube_xy([size.y, size.z, size.x], r, center = true, xy_center = true);
+            rounded_cube_xy([size.y, size.z, size.x], r, xy_center = true, z_center = true);
 }

--- a/utils/core/rounded_rectangle.scad
+++ b/utils/core/rounded_rectangle.scad
@@ -32,16 +32,22 @@ module rounded_rectangle(size, r, center = true, xy_center = true) //! Like `cub
         rounded_square([size.x, size.y], r, xy_center);
 }
 
-module rounded_rectangle_xz(size, r, center = true, xy_center = true) //! Like `cube()` but corners rounded in XZ plane and separate centre options for xy and z.
+module rounded_cube_xy(size, r, center = false, xy_center = false) //! Like `cube()` but corners rounded in XY plane and separate centre options for xy and z.
+{
+    linear_extrude(size.z, center = center)
+        rounded_square([size.x, size.y], r, xy_center);
+}
+
+module rounded_cube_xz(size, r, center = false, xy_center = false) //! Like `cube()` but corners rounded in XZ plane and separate centre options for xy and z.
 {
     translate([xy_center ? 0 : size.x / 2, xy_center ? 0 : size.y / 2, center ? 0 : size.z / 2])
         rotate([90, 0, 0])
-            rounded_rectangle([size.x, size.z, size.y], r, center = true, xy_center = true);
+            rounded_cube_xy([size.x, size.z, size.y], r, center = true, xy_center = true);
 }
 
-module rounded_rectangle_yz(size, r, center = true, xy_center = true) //! Like `cube()` but corners rounded in YX plane and separate centre options for xy and z.
+module rounded_cube_yz(size, r, center = false, xy_center = false) //! Like `cube()` but corners rounded in YX plane and separate centre options for xy and z.
 {
     translate([xy_center ? 0 : size.x / 2, xy_center ? 0 : size.y / 2, center ? 0 : size.z / 2])
         rotate([90, 0, 90])
-            rounded_rectangle([size.y, size.z, size.x], r, center = true, xy_center = true);
+            rounded_cube_xy([size.y, size.z, size.x], r, center = true, xy_center = true);
 }


### PR DESCRIPTION
Having used the new rounded rectangles for a while, I think they should be renamed to `rounded_cubes` and adopt the default centering of the cube.

1. They are 3D objects, so `rounded_cube` is a more accurate name than `rounded_rectangle`
2. The argument that they should not be called a `rounded_cube` because they are only rounded in one plane doesn't apply because of the rounding plane suffix, eg `rounded_cube_xy`
3. Once you adopt the `rounded_cube` name, then the default centering should be the same as for a `cube`.

I've left the original `rounded_rectangle` to keep compatibility with old code.