### PR TITLE
Allow poly_shapes to collapse to non-poly form.

### DIFF
--- a/utils/core/polyholes.scad
+++ b/utils/core/polyholes.scad
@@ -33,20 +33,20 @@
 //! When `twist` is set the resulting cylinder is extended by `eps` at each end so that the exact length of the hole can be used without
 //! leaving a scar on either surface.
 //
-function sides(r) = max(round(4 * r), 3);                                       //! Optimium number of sides for specified radius
-function corrected_radius(r, n = 0)   = r / cos(180 / (n ? n : sides(r)));      //! Adjusted radius to make flats lie on the circle
-function corrected_diameter(d, n = 0) = d / cos(180 / (n ? n : sides(d / 2)));  //! Adjusted diameter to make flats lie on the circle
+function sides(r, n = undef) = is_undef(n) ? max(round(4 * r), 3) : n ? max(n, 3) : r2sides(r); //! Optimium number of sides for specified radius
+function corrected_radius(r, n = undef)   = r / cos(180 / sides(r, n));                         //! Adjusted radius to make flats lie on the circle
+function corrected_diameter(d, n = undef) = 2 * corrected_radius(d / 2 , n);                    //! Adjusted diameter to make flats lie on the circle
 
-module poly_circle(r, sides = 0) { //! Make a circle adjusted to print the correct size
-    n = sides ? sides : sides(r);
-    circle(r = corrected_radius(r,n), $fn = n);
+module poly_circle(r, sides = undef) { //! Make a circle adjusted to print the correct size
+    n = sides(r, sides);
+    circle(r = corrected_radius(r, n), $fn = n);
 }
 
-module poly_cylinder(r, h, center = false, sides = 0, chamfer = false, twist = 0) {//! Make a cylinder adjusted to print the correct size
+module poly_cylinder(r, h, center = false, sides = undef, chamfer = false, twist = 0) {//! Make a cylinder adjusted to print the correct size
     if(twist) {
         slices = ceil(h / layer_height);
         twists = min(twist + 1, slices);
-        sides = sides ? sides : sides(r);
+        sides = sides(r, sides);
         rot = 360 / sides / twists * (twists < slices ? (1 + 1 / slices) : 1);
         if(center)
             for(side = [0, 1])
@@ -64,10 +64,10 @@ module poly_cylinder(r, h, center = false, sides = 0, chamfer = false, twist = 0
             poly_circle(r, sides);
 
     if(h && chamfer)
-        poly_cylinder(r + layer_height, center ? layer_height * 2 : layer_height, center, sides = sides ? sides : sides(r));
+        poly_cylinder(r + layer_height, center ? layer_height * 2 : layer_height, center, sides = sides(r, sides));
 }
 
-module poly_ring(or, ir, sides = 0) { //! Make a 2D ring adjusted to have the correct internal radius
+module poly_ring(or, ir, sides = undef) { //! Make a 2D ring adjusted to have the correct internal radius
     cir = corrected_radius(ir, sides);
     filaments = (or - cir) / extrusion_width;
     if(filaments > 3 + eps)


### PR DESCRIPTION
Changed the default value of `sides` in `poly_circle` to `1` (which was a previously illegal value) and use this to invoke the calculation of `sides(r)`. This leaves the value of `0` free so that `circle` can be called with `$fn=0`, so the `poly_circle` collapses into a circle.

So `poly_circle(r)` has no change in behaviour, and `poly_circle(r, sides=0)` gives a circle.

`poly_cylinder` and `poly_ring` are similarly changed.

The motivation behind this is to make it easier to use the same code to generate printed and CNC'ed parts.