### PR TITLE
Reordered openscad command line parameters to put output name first.

### DIFF
--- a/scripts/exports.py
+++ b/scripts/exports.py
@@ -142,7 +142,7 @@ def make_parts(target, part_type, parts = None):
                                                 f.write("use <%s/%s>\n" % (reltmp(dir, target), filename))
                                                 f.write("%s();\n" % module);
                                             t = time.time()
-                                            openscad.run("-D$bom=1", "-d", dname, "-o", part_file, part_maker_name)
+                                            openscad.run("-o", part_file, part_maker_name, "-D$bom=1", "-d", dname)
                                             times.add_time(part, t)
                                             if part_type == 'stl':
                                                 bounds = c14n_stl.canonicalise(part_file)

--- a/scripts/openscad.py
+++ b/scripts/openscad.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 import subprocess, sys
 
 def run_list(args, silent = False, verbose = False):
-    cmd = ["openscad", "--hardwarnings"] + args
+    cmd = ["openscad"] + args + ["--hardwarnings"]
     if not silent:
         for arg in cmd:
             print(arg, end=" ")

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -94,7 +94,7 @@ def render(target, type):
             cam = "--camera=0,0,0,70,0,315,500" if type == 'stl' else "--camera=0,0,0,0,0,0,500"
             render = "--preview" if type == 'stl' or colour != pp1 else "--render"
             tmp_name = tmp_dir + '/' + part[:-4] + '.png'
-            openscad.run(colour_scheme, "--projection=p", "--imgsize=4096,4096", cam, render, "--autocenter", "--viewall", "-o", tmp_name, png_maker_name);
+            openscad.run("-o", tmp_name, png_maker_name, colour_scheme, "--projection=p", "--imgsize=4096,4096", cam, render, "--autocenter", "--viewall");
             do_cmd(("magick "+ tmp_name + " -trim -resize 280x280 -background %s -gravity Center -extent 280x280 -bordercolor %s -border 10 %s"
                     % (background, background, tmp_name)).split())
             update_image(tmp_name, png_name)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -116,7 +116,7 @@ def tests(tests):
         libtest = True
         lib_blurb = scrape_blurb(scad_name)
         if not os.path.isfile(png_name):
-            openscad.run(colour_scheme, "--projection=p", "--imgsize=%d,%d" % (w, h), "--camera=0,0,0,50,0,340,500", "--autocenter", "--viewall", "-o", png_name, scad_name);
+            openscad.run(scad_name, "-o", png_name, colour_scheme, "--projection=p", "--imgsize=%d,%d" % (w, h), "--camera=0,0,0,50,0,340,500", "--autocenter", "--viewall");
             do_cmd(["magick", png_name, "-trim", "-resize", "1280", "-bordercolor", background, "-border", "10", png_name])
     else:
         #
@@ -237,7 +237,7 @@ def tests(tests):
                 print(changed)
                 t = time.time()
                 tmp_name = tmp_dir + '/tmp.png'
-                openscad.run_list(options.list() + ["-D$bom=2", colour_scheme, "--projection=p", "--imgsize=%d,%d" % (w, h), "--camera=0,0,0,70,0,315,500", "--autocenter", "--viewall", "-d", dname, "-o", tmp_name, scad_name]);
+                openscad.run_list([scad_name, "-o", tmp_name] + options.list() + ["-D$bom=2", colour_scheme, "--projection=p", "--imgsize=%d,%d" % (w, h), "--camera=0,0,0,70,0,315,500", "--autocenter", "--viewall", "-d", dname]);
                 times.add_time(scad_name, t)
                 do_cmd(["magick", tmp_name, "-trim", "-resize", "1000x600", "-bordercolor", background, "-border", "10", tmp_name])
                 update_image(tmp_name, png_name)

--- a/scripts/views.py
+++ b/scripts/views.py
@@ -221,7 +221,7 @@ def views(target, do_assemblies = None):
                                                 target_def = ['-D$target="%s"' % target] if target else []
                                                 cwd_def = ['-D$cwd="%s"' % os.getcwd().replace('\\', '/')]
                                                 view_def = ['--viewall', '--autocenter'] if not (zoomed & (1 << explode)) else ['--camera=0,0,0,55,0,25,140']
-                                                openscad.run_list(options.list() + target_def + cwd_def + view_def +["-D$pose=1", "-D$explode=%d" % explode, colour_scheme, "--projection=p", "--imgsize=4096,4096", "-d", dname, "-o", tmp_name, png_maker_name]);
+                                                openscad.run_list(["-o", tmp_name, png_maker_name] + options.list() + target_def + cwd_def + view_def + ["-D$pose=1", "-D$explode=%d" % explode, colour_scheme, "--projection=p", "--imgsize=4096,4096", "-d", dname]);
                                                 times.add_time(png_name, t)
                                                 do_cmd(["magick", tmp_name, "-trim", "-resize", "1004x1004", "-bordercolor", background, "-border", "10", tmp_name])
                                                 update_image(tmp_name, png_name)


### PR DESCRIPTION
Having the output file name first makes it easier to see what file the build is currently working on, which is handy for a long build.