### PR TITLE
Improved resilience of compare_images.

### DIFF
--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -60,7 +60,8 @@ def compare_images(a, b, c):
     with open(log_name, 'w') as output:
         do_cmd(("magick compare -metric AE -fuzz %d%% %s %s %s" % (fuzz, a, b, c)).split(), output = output)
     with open(log_name, 'r') as f:
-        pixels = int(float(f.read().strip()))
+        pixels = f.read().strip()
+        pixels = int(float(pixels if pixels.isnumeric() else -1))
     os.remove(log_name)
     return pixels
 


### PR DESCRIPTION
Sometimes `magick compare` returns a string, eg

"compare: image widths or heights differ `tests/png/frontface.png' @ error/compare.c/CompareImagesCommand/1160."

This PR makes `tests.py` resilient to that.