### PR TITLE
Added translated children to pulley.

### DIFF
--- a/vitamins/pulley.scad
+++ b/vitamins/pulley.scad
@@ -138,6 +138,10 @@ module pulley(type, colour = silver) { //! Draw a pulley
         else
             core();
     }
+
+    if($children)
+        translate_z(pulley_height(type))
+            children();
 }
 
 module pulley_assembly(type, colour = silver) { //! Draw a pulley with its grub screws in place


### PR DESCRIPTION
If a pulley has children, they are added translated by `pulley_height`. This allows code such as:
```
washer(M3_washer)
    pulley(GT2x20_toothed_idler)
        washer(M3_washer);
```