### PR TITLE
Removed hotend global enums.

### DIFF
--- a/global_defs.scad
+++ b/global_defs.scad
@@ -73,11 +73,6 @@ hs_grub   = 4;     // pulley set screw
 hs_cs_cap = 5;
 hs_dome   = 6;
 //
-// Hot end descriptions
-//
-jhead   = 1;
-e3d     = 2;
-//
 // Face enumeration
 //
 f_bottom = 0;

--- a/tests/hot_ends.scad
+++ b/tests/hot_ends.scad
@@ -19,18 +19,13 @@
 include <../utils/core/core.scad>
 use <../utils/layout.scad>
 
-use <../vitamins/jhead.scad>
-use <../vitamins/e3d.scad>
 include <../vitamins/hot_ends.scad>
 
 module hot_ends()
     layout([for(h = hot_ends) 40])
         translate([-20, 0])
             rotate(90)
-                if($i == 0)
-                    jhead_hot_end_assembly(hot_ends[$i], 3);
-                else
-                    e3d_hot_end_assembly(hot_ends[$i], 3, bowden = $i == 3);
+                hot_end(hot_ends[$i], 3, bowden = $i == 3);
 
 if($preview)
     hot_ends();

--- a/tests/hot_ends.scad
+++ b/tests/hot_ends.scad
@@ -19,13 +19,18 @@
 include <../utils/core/core.scad>
 use <../utils/layout.scad>
 
+use <../vitamins/jhead.scad>
+use <../vitamins/e3d.scad>
 include <../vitamins/hot_ends.scad>
 
 module hot_ends()
     layout([for(h = hot_ends) 40])
         translate([-20, 0])
             rotate(90)
-                hot_end(hot_ends[$i], 3, bowden = $i == 3);
+                if($i == 0)
+                    jhead_hot_end_assembly(hot_ends[$i], 3);
+                else
+                    e3d_hot_end_assembly(hot_ends[$i], 3, bowden = $i == 3);
 
 if($preview)
     hot_ends();

--- a/vitamins/hot_end.scad
+++ b/vitamins/hot_end.scad
@@ -22,9 +22,7 @@
 //!
 //! Needs updating as mostly obsolete versions.
 //
-include <../core.scad>
-
-function hot_end_style(type)              = type[1];    //! Basic type, jhead or e3d
+function hot_end_need_cooling(type)       = type[1];    //! Has own fan so don't need cooling hole in the duct
 function hot_end_part(type)               = type[2];    //! Description
 function hot_end_total_length(type)       = type[3];    //! Length from nozzle tip to the top
 function hot_end_inset(type)              = type[4];    //! The length that goes into the mounting
@@ -35,19 +33,7 @@ function hot_end_groove_dia(type)         = type[8];    //! Groove internal diam
 function hot_end_groove(type)             = type[9];    //! Groove length
 function hot_end_duct_radius(type)        = type[10];   //! Require radius to clear the heater block
 function hot_end_duct_offset(type)        = type[11];   //! Offset of circular duct centre from the nozzle
-function hot_end_need_cooling(type)       = hot_end_style(type) != e3d; //! Has own fan so don't need cooling hole in the duct
 function hot_end_duct_height_nozzle(type) = type[12];   //! Duct height at nozzle end
 function hot_end_duct_height_fan(type)    = type[13];   //! Duct height at fan end
 
 function hot_end_length(type) = hot_end_total_length(type) - hot_end_inset(type); //! The amount the hot end extends below its mounting
-
-use <jhead.scad>
-use <e3d.scad>
-
-module hot_end(type, filament, naked = false, resistor_wire_rotate = [0,0,0], bowden = false) { //! Draw specified hot end
-    if(hot_end_style(type) == jhead)
-        jhead_hot_end_assembly(type, filament, naked);
-
-    if(hot_end_style(type) == e3d)
-        e3d_hot_end_assembly(type, filament, naked, resistor_wire_rotate, bowden);
-}

--- a/vitamins/hot_end.scad
+++ b/vitamins/hot_end.scad
@@ -22,7 +22,7 @@
 //!
 //! Needs updating as mostly obsolete versions.
 //
-function hot_end_need_cooling(type)       = type[1];    //! Has own fan so don't need cooling hole in the duct
+function hot_end_style(type)              = type[1];    //! Basic type, jhead or e3d
 function hot_end_part(type)               = type[2];    //! Description
 function hot_end_total_length(type)       = type[3];    //! Length from nozzle tip to the top
 function hot_end_inset(type)              = type[4];    //! The length that goes into the mounting
@@ -33,7 +33,20 @@ function hot_end_groove_dia(type)         = type[8];    //! Groove internal diam
 function hot_end_groove(type)             = type[9];    //! Groove length
 function hot_end_duct_radius(type)        = type[10];   //! Require radius to clear the heater block
 function hot_end_duct_offset(type)        = type[11];   //! Offset of circular duct centre from the nozzle
+function hot_end_need_cooling(type)       = hot_end_style(type) != "e3d"; //! Has own fan so don't need cooling hole in the duct
 function hot_end_duct_height_nozzle(type) = type[12];   //! Duct height at nozzle end
 function hot_end_duct_height_fan(type)    = type[13];   //! Duct height at fan end
 
 function hot_end_length(type) = hot_end_total_length(type) - hot_end_inset(type); //! The amount the hot end extends below its mounting
+
+use <jhead.scad>
+use <e3d.scad>
+
+module hot_end(type, filament, naked = false, resistor_wire_rotate = [0,0,0], bowden = false) { //! Draw specified hot end
+    if(hot_end_style(type) == "jhead")
+        jhead_hot_end_assembly(type, filament, naked);
+    else if(hot_end_style(type) == "e3d")
+        e3d_hot_end_assembly(type, filament, naked, resistor_wire_rotate, bowden);
+    else
+        assert(false, "Invalid hotend style");
+}

--- a/vitamins/hot_ends.scad
+++ b/vitamins/hot_ends.scad
@@ -20,23 +20,23 @@
 //
 // Hot end descriptions
 //
-//                        s       p                    l    i    d      i l  c           s g    g     d   d              d a   d a
-//                        t       a                    e    n    i      n e  o           c r    r     u   u              u t   u t
-//                        y       r                    n    s    a      s n  l           r o    o     c   c              c     c
+//                        c       p                    l    i    d      i l  c           s g    g     d   d              d a   d a
+//                        o       a                    e    n    i      n e  o           c r    r     u   u              u t   u t
+//                        o       r                    n    s    a      s n  l           r o    o     c   c              c     c
 //                        l       t                    g    e           u g  o           e o    o     t   t              t n   t f
-//                        e                            t    t           l t  u           w v    v                          o     a
-//                                                     h                a h  r             e    e     r   o              h z   h n
-//                                                                      t                p            a   f              e z   e
+//                        i                            t    t           l t  u           w v    v                          o     a
+//                        n                            h                a h  r             e    e     r   o              h z   h n
+//                        g                                             t                p            a   f              e z   e
 //                                                                      o                i d    w     d   f              i l   i
 //                                                                      r                t i    i     i   s              g e   g
 //                                                                                       c a    d     u   e              h     h
 //                                                                                       h      t     s   t              t     t
 //                                                                                              h
 //
-JHeadMk5  = ["JHeadMk5",  jhead, "JHead MK5",         51.2,  4.75,16,    40, grey(20),   12,    4.64, 13, [0, 2.38, -5], 20,   20];
-E3Dv5     = ["E3Dv5",     e3d,   "E3D V5 direct",       70,  3.7, 16,  50.1, "silver",   12,    6,    15, [1, 5,  -4.5], 14.5, 28];
-E3Dv6     = ["E3Dv6",     e3d,   "E3D V6 direct",       62,  3.7, 16,  42.7, "silver",   12,    6,    15, [1, 5,  -4.5], 14,   21];
-E3D_clone = ["E3D_clone", e3d,   "E3D clone aliexpress",66,  6.8, 16,    46, "silver",   12,    5.6,  15, [1, 5,  -4.5], 14.5, 21];
+JHeadMk5  = ["JHeadMk5",  true,  "JHead MK5",         51.2,  4.75,16,    40, grey(20),   12,    4.64, 13, [0, 2.38, -5], 20,   20];
+E3Dv5     = ["E3Dv5",     false, "E3D V5 direct",       70,  3.7, 16,  50.1, "silver",   12,    6,    15, [1, 5,  -4.5], 14.5, 28];
+E3Dv6     = ["E3Dv6",     false, "E3D V6 direct",       62,  3.7, 16,  42.7, "silver",   12,    6,    15, [1, 5,  -4.5], 14,   21];
+E3D_clone = ["E3D_clone", false, "E3D clone aliexpress",66,  6.8, 16,    46, "silver",   12,    5.6,  15, [1, 5,  -4.5], 14.5, 21];
 
 hot_ends = [JHeadMk5, E3Dv5, E3Dv6, E3D_clone];
 

--- a/vitamins/hot_ends.scad
+++ b/vitamins/hot_ends.scad
@@ -20,23 +20,23 @@
 //
 // Hot end descriptions
 //
-//                        c       p                    l    i    d      i l  c           s g    g     d   d              d a   d a
-//                        o       a                    e    n    i      n e  o           c r    r     u   u              u t   u t
-//                        o       r                    n    s    a      s n  l           r o    o     c   c              c     c
+//                        s       p                    l    i    d      i l  c           s g    g     d   d              d a   d a
+//                        t       a                    e    n    i      n e  o           c r    r     u   u              u t   u t
+//                        y       r                    n    s    a      s n  l           r o    o     c   c              c     c
 //                        l       t                    g    e           u g  o           e o    o     t   t              t n   t f
-//                        i                            t    t           l t  u           w v    v                          o     a
-//                        n                            h                a h  r             e    e     r   o              h z   h n
-//                        g                                             t                p            a   f              e z   e
+//                        e                            t    t           l t  u           w v    v                          o     a
+//                                                     h                a h  r             e    e     r   o              h z   h n
+//                                                                      t                p            a   f              e z   e
 //                                                                      o                i d    w     d   f              i l   i
 //                                                                      r                t i    i     i   s              g e   g
 //                                                                                       c a    d     u   e              h     h
 //                                                                                       h      t     s   t              t     t
 //                                                                                              h
 //
-JHeadMk5  = ["JHeadMk5",  true,  "JHead MK5",         51.2,  4.75,16,    40, grey(20),   12,    4.64, 13, [0, 2.38, -5], 20,   20];
-E3Dv5     = ["E3Dv5",     false, "E3D V5 direct",       70,  3.7, 16,  50.1, "silver",   12,    6,    15, [1, 5,  -4.5], 14.5, 28];
-E3Dv6     = ["E3Dv6",     false, "E3D V6 direct",       62,  3.7, 16,  42.7, "silver",   12,    6,    15, [1, 5,  -4.5], 14,   21];
-E3D_clone = ["E3D_clone", false, "E3D clone aliexpress",66,  6.8, 16,    46, "silver",   12,    5.6,  15, [1, 5,  -4.5], 14.5, 21];
+JHeadMk5  = ["JHeadMk5", "jhead","JHead MK5",         51.2,  4.75,16,    40, grey(20),   12,    4.64, 13, [0, 2.38, -5], 20,   20];
+E3Dv5     = ["E3Dv5",     "e3d", "E3D V5 direct",       70,  3.7, 16,  50.1, "silver",   12,    6,    15, [1, 5,  -4.5], 14.5, 28];
+E3Dv6     = ["E3Dv6",     "e3d", "E3D V6 direct",       62,  3.7, 16,  42.7, "silver",   12,    6,    15, [1, 5,  -4.5], 14,   21];
+E3D_clone = ["E3D_clone", "e3d", "E3D clone aliexpress",66,  6.8, 16,    46, "silver",   12,    5.6,  15, [1, 5,  -4.5], 14.5, 21];
 
 hot_ends = [JHeadMk5, E3Dv5, E3Dv6, E3D_clone];
 


### PR DESCRIPTION
Got rid of the global enums `jhead` and `e3d`. A global hotend enum is not very desirable.