### PR TITLE
Removed need for supports from drag chain.

### DIFF
--- a/printed/drag_chain.scad
+++ b/printed/drag_chain.scad
@@ -152,7 +152,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                             rotate(180)
                                                 teardrop_2d(r = r, extra_x = 2 * clearance);
                                         translate([0, r])
-                                            square([r, r / 2]);
+                                            square([r, r / 2.5]);
                                     }
 
                                     translate([outer_end_x - eps, 0])

--- a/printed/drag_chain.scad
+++ b/printed/drag_chain.scad
@@ -152,7 +152,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                             rotate(180)
                                                 teardrop_2d(r = r, extra_x = 2 * clearance);
                                         translate([0, r])
-                                            square([r, r / 2.5]);
+                                            square([r, r / 2]);
                                     }
 
                                     translate([outer_end_x - eps, 0])
@@ -160,10 +160,10 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                 }
                             // Conical horihole for pin
                             if(!start)
-                                translate([socket_x, r, -side * (wall + clearance) / 2])
+                                translate([socket_x, r, -side * wall / 2])
                                     hull() {
                                         horihole(r = pin_r, z = r, h = eps);
-                                        translate_z(side * (pin_h + clearance))
+                                        translate_z(side * pin_h)
                                             horihole(r = pin_r - pin_h, z = r, h = eps);
                                     }
                         }
@@ -175,7 +175,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                     translate([pin_x, r]) {
                                         rotate(180)
                                             teardrop_2d(r = r, extra_x = 2 * clearance);
-                                        square([r, r / 2.5]);
+                                        square([r, r / 2]);
                                     }
                                 } else {
                                     translate([os.x - eps, 0])
@@ -200,13 +200,20 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
             // Roof, actually the floor when printed
             roof_x = start ? 0 : inner_x;
             roof_end = end ? s.x + 2 * r : s.x + r - twall - clearance;
-            translate([roof_x, -s.y / 2 - wall, 0])
+            translate([roof_x, -s.y / 2 - wall, 0]) {
                 hull() {
                     cube([roof_end - roof_x, s.y + 2 * wall, twall]);
                     if(!end)
                         cube([roof_end - roof_x + twall / 2, s.y + 2 * wall, twall / 2]);
                 }
-
+                if(!start)
+                    hull() {
+                        translate([-3 * twall / 4 + clearance, -wall, 0])
+                            cube([3 * twall / 4 - clearance, s.y + 4 * wall, twall / 3]);
+                        translate([0, -wall, 0])
+                            cube([eps, s.y + 4 * wall, twall]);
+                    }
+            }
             // Floor, actually the roof when printed
             floor_x = roof_x;
             floor_end = end ? s.x + 2 * r : s.x + r - clearance;

--- a/printed/drag_chain.scad
+++ b/printed/drag_chain.scad
@@ -120,9 +120,8 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
     outer_normal_x =  pin_x - r - clearance;     // s.x - clearance
     outer_end_x = end ? os.x : outer_normal_x;
 
-    inner_x = start ? 0 : s.x - r / 2 + clearance;
+    inner_x = start ? 0 : socket_x + r + clearance;
 
-    roof_x_normal = 2 * r - twall;
     assert(r + norm([drag_chain_cam_x(type), r - drag_chain_twall(type)]) + clearance <= outer_normal_x - wall || start, "Link must be longer");
 
     difference() {
@@ -190,7 +189,10 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
             roof_x = start ? 0 : inner_x;
             roof_end = end ? s.x + 2 * r : s.x + r - twall - clearance;
             translate([roof_x, -s.y / 2 - wall, 0])
-                cube([roof_end - roof_x , s.y + 2 * wall, twall]);
+                hull() {
+                    cube([roof_end - roof_x, s.y + 2 * wall, twall]);
+                    cube([roof_end - roof_x + twall / 2, s.y + 2 * wall, twall / 2]);
+                }
 
             // Floor, actually the roof when printed
             floor_x = roof_x;

--- a/printed/drag_chain.scad
+++ b/printed/drag_chain.scad
@@ -113,7 +113,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
     clearance = drag_chain_clearance(type);
     r = os.z / 2;
     pin_r = r / 2 + wall / 4;
-    pin_z = min(wall, pin_r - 0.4);
+    pin_h = min(wall, pin_r - 0.4);
 
     socket_x = r;
     pin_x = socket_x + s.x;
@@ -160,8 +160,8 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                 translate([socket_x, r, -side * (wall + clearance) / 2])
                                     hull() {
                                         horihole(r = pin_r, z = r, h = eps);
-                                        translate_z(side * (pin_z + clearance))
-                                            horihole(r = pin_r - pin_z, z = r, h = eps);
+                                        translate_z(side * (pin_h + clearance))
+                                            horihole(r = pin_r - pin_h, z = r, h = eps);
                                     }
                         }
                     // Inner cheeks
@@ -186,7 +186,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                         if(!end)
                             translate([pin_x, r, side * wall / 2])
                                 vflip(side == -1)
-                                    cylinder(r1 = pin_r, r2 = pin_r - pin_z, h = pin_z);
+                                    cylinder(r1 = pin_r, r2 = pin_r - pin_h, h = pin_h);
                     }
 
                     // Cheek joint

--- a/printed/drag_chain.scad
+++ b/printed/drag_chain.scad
@@ -128,8 +128,11 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
     module teardrop_2d(r, extra_x) {
         hull() {
             circle4n(r);
+            square_size = [2 * r * (sqrt(2) - 1) + extra_x, r];
             translate([0, r / 2])
-                square([2 * r * (sqrt(2) - 1) + extra_x, r], center = true);
+                square(square_size, center = true);
+            translate([0, 3 * r / 4])
+                square([square_size.x + r / 2, eps], center = true);
         }
     }
 
@@ -172,7 +175,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                     translate([pin_x, r]) {
                                         rotate(180)
                                             teardrop_2d(r = r, extra_x = 2 * clearance);
-                                        square([r, r/2]);
+                                        square([r, r / 2.5]);
                                     }
                                 } else {
                                     translate([os.x - eps, 0])

--- a/printed/drag_chain.scad
+++ b/printed/drag_chain.scad
@@ -200,7 +200,8 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
             translate([roof_x, -s.y / 2 - wall, 0])
                 hull() {
                     cube([roof_end - roof_x, s.y + 2 * wall, twall]);
-                    cube([roof_end - roof_x + twall / 2, s.y + 2 * wall, twall / 2]);
+                    if(!end)
+                        cube([roof_end - roof_x + twall / 2, s.y + 2 * wall, twall / 2]);
                 }
 
             // Floor, actually the roof when printed

--- a/printed/drag_chain.scad
+++ b/printed/drag_chain.scad
@@ -113,6 +113,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
     clearance = drag_chain_clearance(type);
     r = os.z / 2;
     pin_r = r / 2 + wall / 4;
+    pin_z = min(wall, pin_r - 0.4);
 
     socket_x = r;
     pin_x = socket_x + s.x;
@@ -159,8 +160,8 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                 translate([socket_x, r, -side * (wall + clearance) / 2])
                                     hull() {
                                         horihole(r = pin_r, z = r, h = eps);
-                                        translate_z(side * (wall + clearance))
-                                            horihole(r = pin_r - wall, z = r, h = eps);
+                                        translate_z(side * (pin_z + clearance))
+                                            horihole(r = pin_r - pin_z, z = r, h = eps);
                                     }
                         }
                     // Inner cheeks
@@ -183,9 +184,9 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                             }
                         // Pin, cone shaped so no supports required
                         if(!end)
-                            translate([pin_x, r, side * wall])
+                            translate([pin_x, r, side * wall / 2])
                                 vflip(side == -1)
-                                    cylinder(r1 = pin_r, r2 = pin_r - wall, h = wall, center=true);
+                                    cylinder(r1 = pin_r, r2 = pin_r - pin_z, h = pin_z);
                     }
 
                     // Cheek joint

--- a/printed/drag_chain.scad
+++ b/printed/drag_chain.scad
@@ -124,6 +124,14 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
 
     assert(r + norm([drag_chain_cam_x(type), r - drag_chain_twall(type)]) + clearance <= outer_normal_x - wall || start, "Link must be longer");
 
+    module teardrop_2d(r, extra_x) {
+        hull() {
+            circle4n(r);
+            translate([0, r / 2])
+                square([2 * r * (sqrt(2) - 1) + extra_x, r], center = true);
+        }
+    }
+
     difference() {
         union() {
             for(side = [-1, 1])
@@ -138,9 +146,9 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                     } else {
                                         translate([socket_x, r])
                                             rotate(180)
-                                                teardrop(r = r, h = 0, extra_x = 2 * clearance);
+                                                teardrop_2d(r = r, extra_x = 2 * clearance);
                                         translate([0, r])
-                                            square([r, r/2]);
+                                            square([r, r / 2.5]);
                                     }
 
                                     translate([outer_end_x - eps, 0])
@@ -162,7 +170,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                 if(!end) {
                                     translate([pin_x, r]) {
                                         rotate(180)
-                                            teardrop(r = r, h = 0, extra_x = 2 * clearance);
+                                            teardrop_2d(r = r, extra_x = 2 * clearance);
                                         square([r, r/2]);
                                     }
                                 } else {

--- a/printed/drag_chain.scad
+++ b/printed/drag_chain.scad
@@ -112,8 +112,8 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
     os = drag_chain_outer_size(type);
     clearance = drag_chain_clearance(type);
     r = os.z / 2;
-    pin_r = r / 2 + wall / 4;
-    pin_h = min(wall, pin_r - 0.4);
+    pin_r = r / 2 - 0.2;
+    pin_h = min(wall + clearance, 2 * pin_r - 1); // ensure minimum radius of top of pin
 
     socket_x = r;
     pin_x = socket_x + s.x;
@@ -152,7 +152,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                             rotate(180)
                                                 teardrop_2d(r = r, extra_x = 2 * clearance);
                                         translate([0, r])
-                                            square([r, r / 2.5]);
+                                            square([r, r / 2.5]); // this shouldn't protrude when link rotates
                                     }
 
                                     translate([outer_end_x - eps, 0])
@@ -160,11 +160,11 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                 }
                             // Conical horihole for pin
                             if(!start)
-                                translate([socket_x, r, -side * wall / 2])
+                                translate([socket_x, r, -side * (wall / 2 + clearance)])
                                     hull() {
-                                        horihole(r = pin_r, z = r, h = eps);
+                                        horihole(r = pin_r + pin_h / 2, z = r, h = eps);
                                         translate_z(side * pin_h)
-                                            horihole(r = pin_r - pin_h, z = r, h = eps);
+                                            horihole(r = pin_r - pin_h / 2, z = r, h = eps);
                                     }
                         }
                     // Inner cheeks
@@ -175,7 +175,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                                     translate([pin_x, r]) {
                                         rotate(180)
                                             teardrop_2d(r = r, extra_x = 2 * clearance);
-                                        square([r, r / 2]);
+                                        square([r, r / 1.5]); // this can protrude when link rotates
                                     }
                                 } else {
                                     translate([os.x - eps, 0])
@@ -189,7 +189,7 @@ module drag_chain_link(type, start = false, end = false, check_kids = true) { //
                         if(!end)
                             translate([pin_x, r, side * wall / 2])
                                 vflip(side == -1)
-                                    cylinder(r1 = pin_r, r2 = pin_r - pin_h, h = pin_h);
+                                    cylinder(r1 = pin_r + pin_h / 2, r2 = pin_r - pin_h / 2, h = pin_h + eps);
                     }
 
                     // Cheek joint

--- a/utils/core/teardrops.scad
+++ b/utils/core/teardrops.scad
@@ -24,7 +24,7 @@
 //! Using teardrop_plus() or setting the plus option on other modules will elongate the teardrop vertically by the layer height, so when sliced the staircase tips
 //! do not intrude into the circle. See <https://hydraraptor.blogspot.com/2020/07/horiholes-2.html>
 //
-module teardrop(h, r, center = true, truncate = true, chamfer = 0, chamfer_both_ends = true, plus = false) { //! For making horizontal holes that don't need support material, set `truncate = false` to make traditional RepRap teardrops that don't even need bridging
+module teardrop(h, r, center = true, truncate = true, chamfer = 0, chamfer_both_ends = true, plus = false, extra_x = 0) { //! For making horizontal holes that don't need support material, set `truncate = false` to make traditional RepRap teardrops that don't even need bridging
     module teardrop_2d(r, truncate) {
         er = layer_height / 2 - eps;    // Extrusion edge radius
         R = plus ? r + er : r;          // Corrected radius
@@ -39,7 +39,7 @@ module teardrop(h, r, center = true, truncate = true, chamfer = 0, chamfer_both_
 
                             if(truncate)
                                 translate([0, R / 2])
-                                    square([2 * R * (sqrt(2) - 1), R], center = true);
+                                    square([2 * R * (sqrt(2) - 1) + extra_x, R], center = true);
                             else
                                 polygon([[0, 0], [eps, 0], [0, R * sqrt(2)]]);
                         }

--- a/utils/core/teardrops.scad
+++ b/utils/core/teardrops.scad
@@ -24,7 +24,7 @@
 //! Using teardrop_plus() or setting the plus option on other modules will elongate the teardrop vertically by the layer height, so when sliced the staircase tips
 //! do not intrude into the circle. See <https://hydraraptor.blogspot.com/2020/07/horiholes-2.html>
 //
-module teardrop(h, r, center = true, truncate = true, chamfer = 0, chamfer_both_ends = true, plus = false, extra_x = 0) { //! For making horizontal holes that don't need support material, set `truncate = false` to make traditional RepRap teardrops that don't even need bridging
+module teardrop(h, r, center = true, truncate = true, chamfer = 0, chamfer_both_ends = true, plus = false) { //! For making horizontal holes that don't need support material, set `truncate = false` to make traditional RepRap teardrops that don't even need bridging
     module teardrop_2d(r, truncate) {
         er = layer_height / 2 - eps;    // Extrusion edge radius
         R = plus ? r + er : r;          // Corrected radius
@@ -39,7 +39,7 @@ module teardrop(h, r, center = true, truncate = true, chamfer = 0, chamfer_both_
 
                             if(truncate)
                                 translate([0, R / 2])
-                                    square([2 * R * (sqrt(2) - 1) + extra_x, R], center = true);
+                                    square([2 * R * (sqrt(2) - 1), R], center = true);
                             else
                                 polygon([[0, 0], [eps, 0], [0, R * sqrt(2)]]);
                         }


### PR DESCRIPTION
![link](https://user-images.githubusercontent.com/194586/141988240-28a40c1c-8188-4ec8-bb34-c9ab260c08a6.png)

1. Made pin conical, so it doesn't require supports
2. Used conical horihole in outer cheek for pin
3. Removed cutout in inner cheek
4. Used shape of cheek circumference to limit rotation of links
5. Make clearance a property of the drag chain so it can be altered for printing
chain assemblies
6. Altered teardrops to allow extra width of top.

I've successfully printed a chain of 2 links as a single part by setting `clearance = 0.2`, but this my vary according to your printer.


The use of the cheek profiles to limit the rotation of the links can be seen below:
![DragChain](https://user-images.githubusercontent.com/194586/141987353-31bb1d7c-73d5-4500-bdee-aba4afc18abd.png)
