### PR TITLE
Improvements to core_xy

### DIFF
--- a/tests/core_xy.scad
+++ b/tests/core_xy.scad
@@ -30,22 +30,25 @@ module coreXY_belts_test() {
     plain_idler = coreXY_plain_idler(coreXY_type);
     toothed_idler = coreXY_toothed_idler(coreXY_type);
 
+    pos = [100, 50];
     coreXYPosBL = [0, 0, 0];
     coreXYPosTR = [200, 150, 0];
     separation = [0, coreXY_coincident_separation(coreXY_type).y, pulley_height(plain_idler) + washer_thickness(M3_washer)];
-    pos = [100, 50];
+    x_gap = 10;
 
-    upper_drive_pulley_offset = [40, 10];
+    plain_idler_offset = [10, 5];
+    upper_drive_pulley_offset = [40, 0];
     lower_drive_pulley_offset = [0, 0];
 
     coreXY_belts(coreXY_type,
-        carriagePosition = pos,
-        coreXYPosBL = coreXYPosBL,
-        coreXYPosTR = coreXYPosTR,
-        separation = separation,
-        x_gap = 10,
-        upper_drive_pulley_offset = upper_drive_pulley_offset,
-        lower_drive_pulley_offset = lower_drive_pulley_offset,
+        pos,
+        coreXYPosBL,
+        coreXYPosTR,
+        separation,
+        x_gap,
+        plain_idler_offset,
+        upper_drive_pulley_offset,
+        lower_drive_pulley_offset,
         show_pulleys = true);
 
 
@@ -56,18 +59,18 @@ module coreXY_belts_test() {
 
         // add the screws for the upper drive offset idler pulleys if required
         if (upper_drive_pulley_offset.x > 0) {
-            translate(coreXY_drive_plain_idler_offset(coreXY_type))
-                translate_z(-pulley_offset(plain_idler))
+            translate(coreXY_drive_plain_idler_offset(coreXY_type) + plain_idler_offset)
+                translate([0, -upper_drive_pulley_offset.y, -pulley_offset(plain_idler)])
                     screw(M3_cap_screw, 20);
             translate(coreXY_drive_toothed_idler_offset(coreXY_type))
-                translate_z(-pulley_offset(toothed_idler))
+                translate([0, -upper_drive_pulley_offset.y, -pulley_offset(toothed_idler)])
                     screw(M3_cap_screw, 20);
          } else if (upper_drive_pulley_offset.x < 0) {
-            translate([-pulley_od(plain_idler), coreXY_drive_plain_idler_offset(coreXY_type).y])
-                translate_z(-pulley_offset(plain_idler))
+            translate([-pulley_od(plain_idler), coreXY_drive_plain_idler_offset(coreXY_type).y + plain_idler_offset.y])
+                translate([0, -upper_drive_pulley_offset.y, -pulley_offset(plain_idler)])
                     screw(M3_cap_screw, 20);
-            translate([2*coreXY_drive_pulley_x_alignment(coreXY_type), coreXY_drive_toothed_idler_offset(coreXY_type).y])
-                translate_z(-pulley_offset(toothed_idler))
+            translate([2*coreXY_drive_pulley_x_alignment(coreXY_type) + plain_idler_offset.x, coreXY_drive_toothed_idler_offset(coreXY_type).y])
+                translate([0, -upper_drive_pulley_offset.y, -pulley_offset(toothed_idler)])
                     screw(M3_cap_screw, 20);
         }
     }
@@ -79,18 +82,18 @@ module coreXY_belts_test() {
 
         // add the screws for the lower drive offset idler pulleys if required
         if (lower_drive_pulley_offset.x < 0) {
-            translate([-coreXY_drive_plain_idler_offset(coreXY_type).x, coreXY_drive_plain_idler_offset(coreXY_type).y])
-                translate_z(-pulley_offset(plain_idler))
+            translate([-coreXY_drive_plain_idler_offset(coreXY_type).x - plain_idler_offset.x, coreXY_drive_plain_idler_offset(coreXY_type).y + plain_idler_offset.y])
+                translate([0, -lower_drive_pulley_offset.y, -pulley_offset(plain_idler)])
                     screw(M3_cap_screw, 20);
             translate(coreXY_drive_toothed_idler_offset(coreXY_type))
-                translate_z(-pulley_offset(toothed_idler))
+                translate([0, -lower_drive_pulley_offset.y, -pulley_offset(toothed_idler)])
                     screw(M3_cap_screw, 20);
         } else if (lower_drive_pulley_offset.x > 0) {
-            translate([pulley_od(plain_idler), coreXY_drive_plain_idler_offset(coreXY_type).y])
-                translate_z(-pulley_offset(plain_idler))
+            translate([pulley_od(plain_idler), coreXY_drive_plain_idler_offset(coreXY_type).y + plain_idler_offset.y])
+                translate([0, -lower_drive_pulley_offset.y, -pulley_offset(plain_idler)])
                     screw(M3_cap_screw, 20);
-            translate([-2*coreXY_drive_pulley_x_alignment(coreXY_type), coreXY_drive_toothed_idler_offset(coreXY_type).y])
-                translate_z(-pulley_offset(toothed_idler))
+            translate([-2*coreXY_drive_pulley_x_alignment(coreXY_type) - plain_idler_offset.x, coreXY_drive_toothed_idler_offset(coreXY_type).y])
+                translate([0, -lower_drive_pulley_offset.y, -pulley_offset(toothed_idler)])
                     screw(M3_cap_screw, 20);
         }
     }
@@ -118,13 +121,13 @@ module coreXY_belts_test() {
         translate([coreXYPosBL.x, coreXY_toothed_idler_offset(coreXY_type).y, 0])
             screw(M3_cap_screw, 20);
         // add the screw for the left Y carriage plain idler
-        translate([coreXYPosBL.x + separation.x + coreXY_plain_idler_offset(coreXY_type).x, separation.y + coreXY_plain_idler_offset(coreXY_type).y, separation.z])
+        translate([coreXYPosBL.x + separation.x + coreXY_plain_idler_offset(coreXY_type).x + (upper_drive_pulley_offset.x == 0 ? 0 : plain_idler_offset.x), separation.y + coreXY_plain_idler_offset(coreXY_type).y, separation.z])
             screw(M3_cap_screw, 20);
         // add the screw for the right Y carriage toothed idler
         translate([coreXYPosTR.x + separation.x, coreXY_toothed_idler_offset(coreXY_type).y, separation.z])
             screw(M3_cap_screw, 20);
         // add the screw for the right Y carriage plain idler
-        translate([coreXYPosTR.x - coreXY_plain_idler_offset(coreXY_type).x, separation.y + coreXY_plain_idler_offset(coreXY_type).y, 0])
+        translate([coreXYPosTR.x - coreXY_plain_idler_offset(coreXY_type).x - (lower_drive_pulley_offset.x == 0 ? 0 : plain_idler_offset.x), separation.y + coreXY_plain_idler_offset(coreXY_type).y, 0])
             screw(M3_cap_screw, 20);
     }
 }

--- a/utils/core_xy.scad
+++ b/utils/core_xy.scad
@@ -90,13 +90,13 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
 
     // toothed idler for offset stepper motor drive pulley
     p3t_type = coreXY_toothed_idler(type);
-    p3t = [ -size.x / 2 + (drive_pulley_offset.x > 0 ? 0 : 2 * coreXY_drive_pulley_x_alignment(type)),
+    p3t = [ -size.x / 2 + (drive_pulley_offset.x > 0 ? 0 : plain_idler_offset.x + 2 * coreXY_drive_pulley_x_alignment(type)),
              size.y / 2 + coreXY_drive_pulley_x_alignment(type)
     ];
 
     // y-carriage plain pulley
     p4_type = coreXY_plain_idler(type);
-    p4 = [ -size.x / 2 + pulley_od(p4_type) / 2 + pulley_od(p3d_type) / 2 + coreXY_drive_pulley_x_alignment(type) + plain_idler_offset.x,
+    p4 = [ -size.x / 2 + pulley_od(p4_type) / 2 + pulley_od(p3d_type) / 2 + coreXY_drive_pulley_x_alignment(type) + (drive_pulley_offset.x == 0 ? 0 : plain_idler_offset.x),
            -size.y / 2 + pulley_od(p4_type) / 2 + pos.y + separation_y / 2
     ];
 

--- a/utils/core_xy.scad
+++ b/utils/core_xy.scad
@@ -30,7 +30,6 @@
 //! allows flexible positioning of the motors.
 //
 include <../utils/core/core.scad>
-include <../vitamins/belts.scad>
 include <../vitamins/pulleys.scad>
 
 
@@ -69,7 +68,7 @@ function coreXY_drive_plain_idler_offset(type) = //! Offset of plain drive idler
     [ coreXY_plain_idler_offset(type).x, -(pulley_od(coreXY_plain_idler(type)) + pulley_od(coreXY_drive_pulley(type))) / 2, 0 ];
 
 
-module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_offset = 0, drive_pulley_offset = [0, 0], show_pulleys = false, lower_belt = false, hflip = false) { //! Draw one belt of a coreXY setup
+module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_offset = [0, 0], drive_pulley_offset = [0, 0], show_pulleys = false, lower_belt = false, hflip = false) { //! Draw one belt of a coreXY setup
 
     // y-carriage toothed pulley
     p0_type = coreXY_toothed_idler(type);
@@ -92,19 +91,19 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
     // toothed idler for offset stepper motor drive pulley
     p3t_type = coreXY_toothed_idler(type);
     p3t = [ -size.x / 2 + (drive_pulley_offset.x > 0 ? 0 : 2 * coreXY_drive_pulley_x_alignment(type)),
-            size.y / 2 + coreXY_drive_pulley_x_alignment(type) + drive_pulley_offset.y
+             size.y / 2 + coreXY_drive_pulley_x_alignment(type)
     ];
 
     // y-carriage plain pulley
     p4_type = coreXY_plain_idler(type);
-    p4 = [ -size.x / 2 + pulley_od(p4_type) / 2 + pulley_od(p3d_type) / 2 + coreXY_drive_pulley_x_alignment(type) + plain_idler_offset,
+    p4 = [ -size.x / 2 + pulley_od(p4_type) / 2 + pulley_od(p3d_type) / 2 + coreXY_drive_pulley_x_alignment(type) + plain_idler_offset.x,
            -size.y / 2 + pulley_od(p4_type) / 2 + pos.y + separation_y / 2
     ];
 
     // plain idler for offset stepper motor drive pulley
     p3p_type = p4_type;
     p3p = [ drive_pulley_offset.x > 0 ? p4.x : -p0.x - pulley_od(p0_type),
-            size.y / 2 - pulley_od(p3p_type) / 2 - pulley_od(p3d_type) / 2 + drive_pulley_offset.y
+            size.y / 2 - pulley_od(p3p_type) / 2 - pulley_od(p3d_type) / 2 + plain_idler_offset.y
     ];
 
     // Start and end points
@@ -180,7 +179,7 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
         tooth_colour = lower_belt ? coreXY_lower_tooth_colour(type) : coreXY_upper_tooth_colour(type));
 }
 
-module coreXY(type, size, pos, separation, x_gap, plain_idler_offset = 0, upper_drive_pulley_offset, lower_drive_pulley_offset, show_pulleys = false, left_lower = false) { //! Wrapper module to draw both belts of a coreXY setup
+module coreXY(type, size, pos, separation, x_gap = 0, plain_idler_offset = [0, 0], upper_drive_pulley_offset = [0, 0], lower_drive_pulley_offset = [0, 0], show_pulleys = false, left_lower = false) { //! Wrapper module to draw both belts of a coreXY setup
     translate([size.x / 2 - separation.x / 2, size.y / 2, -separation.z / 2]) {
         // lower belt
         hflip(!left_lower)
@@ -195,10 +194,10 @@ module coreXY(type, size, pos, separation, x_gap, plain_idler_offset = 0, upper_
     }
 }
 
-module coreXY_belts(type, carriagePosition, coreXYPosBL, coreXYPosTR, separation, x_gap = 20, upper_drive_pulley_offset = [0, 0], lower_drive_pulley_offset = [0, 0], show_pulleys = false, left_lower = false) { //! Draw the coreXY belts
+module coreXY_belts(type, carriagePosition, coreXYPosBL, coreXYPosTR, separation, x_gap = 0, plain_idler_offset = [0, 0], upper_drive_pulley_offset = [0, 0], lower_drive_pulley_offset = [0, 0], show_pulleys = false, left_lower = false) { //! Draw the coreXY belts
     assert(coreXYPosBL.z == coreXYPosTR.z);
 
     coreXYSize = coreXYPosTR - coreXYPosBL;
     translate(coreXYPosBL)
-        coreXY(type, coreXYSize, [carriagePosition.x - coreXYPosBL.x, carriagePosition.y - coreXYPosBL.y], separation = separation, x_gap = x_gap, plain_idler_offset = 0, upper_drive_pulley_offset = upper_drive_pulley_offset, lower_drive_pulley_offset = lower_drive_pulley_offset, show_pulleys = show_pulleys, left_lower = left_lower);
+        coreXY(type, coreXYSize, [carriagePosition.x - coreXYPosBL.x, carriagePosition.y - coreXYPosBL.y], separation, x_gap, plain_idler_offset, upper_drive_pulley_offset, lower_drive_pulley_offset, show_pulleys, left_lower);
 }


### PR DESCRIPTION
1. Better default parameters
2. Changed plain_idler_offset to work in x and y, to facilitate larger idler pulleys

This example uses 25 tooth idler pulleys - they have larger and wider bearings than 20 and 16 tooth pulleys and are hence more durable.
![CoreXY](https://user-images.githubusercontent.com/194586/143686910-b2e2f04c-08b7-4edb-b595-891118214075.png)
