### PR TITLE
Allow configuration of teardrop angle.

### DIFF
--- a/global_defs.scad
+++ b/global_defs.scad
@@ -35,6 +35,7 @@ cnc_bit_r       = is_undef($cnc_bit_r)       ? 1.2    : $cnc_bit_r;       // min
 show_rays       = is_undef($show_rays)       ? false  : $show_rays;       // show camera sight lines and light direction
 show_threads    = is_undef($show_threads)    ? false  : $show_threads;    // show screw threads
 show_plugs      = is_undef($show_plugs)      ? false  : $show_plugs;      // plugs on headers
+teardrop_angle  = is_undef($teardrop_angle)  ? 45     : $teardrop_angle;  // teardrop angle
 pp1_colour      = is_undef($pp1_colour)      ? rr_green     : $pp1_colour;// printed part colour 1, RepRap logo colour
 pp2_colour      = is_undef($pp2_colour)      ? crimson      : $pp2_colour;// printed part colour 2
 pp3_colour      = is_undef($pp3_colour)      ? "SteelBlue"  : $pp3_colour;// printed part colour 3

--- a/utils/core/teardrops.scad
+++ b/utils/core/teardrops.scad
@@ -37,11 +37,14 @@ module teardrop(h, r, center = true, truncate = true, chamfer = 0, chamfer_both_
                         translate([offset, 0]) {
                             circle4n(R);
 
-                            if(truncate)
-                                translate([0, R / 2])
-                                    square([2 * R * (sqrt(2) - 1), R], center = true);
-                            else
-                                polygon([[0, 0], [eps, 0], [0, R * sqrt(2)]]);
+                            if (teardrop_angle > 0) {
+                                x = sin(teardrop_angle) - (1 - cos(teardrop_angle)) / tan(teardrop_angle);
+                                if(truncate)
+                                    translate([0, R / 2])
+                                        square([2 * R * x, R], center = true);
+                                else
+                                    polygon([[0, 0], [eps, 0], [0, R * (1 + x * tan(min(teardrop_angle, 90 - eps)))]]);
+                            }
                         }
                         translate([0, -2 * R])
                             square([R, 4 * R]);


### PR DESCRIPTION
In most cases a teardrop angle of 45 degrees is fine, but there are cases when this does not give sufficient overlap between layers and a slightly steeper teardrop angle, say 50 or 55 degrees is desirable. This change allows this. 

The teardrop angle is defaulted to its current value of 45 degrees.

In particular I print mostly functional parts and for these (for both strength and speed of printing) I tend to use a 0.6mm nozzle with 0.5mm layer height and 1.0mm extrusion width. For these large layers, a teardrop angle of 50 or 55 degrees gives better results.
