### PR TITLE
Added support for terminals on PCBs.

### DIFF
--- a/vitamins/pcb.scad
+++ b/vitamins/pcb.scad
@@ -38,6 +38,7 @@ use <led.scad>
 use <dip.scad>
 use <axial.scad>
 use <smd.scad>
+use <terminal.scad>
 include <potentiometers.scad>
 
 function pcb_name(type)         = type[1];  //! Description
@@ -1088,6 +1089,7 @@ module pcb_component(comp, cutouts = false, angle = undef) { //! Draw pcb compon
             if(show(comp, "smd_res"))       smd_resistor(comp[4], comp[5]);
             if(show(comp, "smd_cap"))       smd_capacitor(comp[4], comp[5]);
             if(show(comp, "vero_pin"))      vero_pin(param(4, false));
+            if(show(comp, "terminal"))      terminal_block(comp[5], comp[4]);
         }
     }
 }

--- a/vitamins/pcbs.scad
+++ b/vitamins/pcbs.scad
@@ -198,6 +198,34 @@ Duex5 = ["Duex5", "Duex5 expansion board",
                                                                     ]),
                                                                     []];
 
+BTT_RELAY_V1_2 = [
+    "BTT_RELAY_V1_2", "BigTreeTech Relay Module v1.2",
+    80.4, 36.3, 1.5, // size
+    1, // corner radius
+    3, // mounting hole diameter
+    5, // pad around mounting hole
+    grey(25), // color
+    false, // true if parts should be separate BOM items
+    [ // hole positions
+        [3, 3.5], [-3, 3.5], [3, -3.5], [-3, -3.5]
+    ],
+    [ // components
+        [  44.5,  10.0,    0, "block", 25,  20,    15.8, grey(20) ],
+        [  47.5,  -7.6,    0, "block", 19,  15.25, 15.8, "SkyBlue" ],
+        //[ -14.5,  18.15,   0, "block", 16,  30,    17.0, grey(25) ],
+        //[ -14.5,  18.15,   0, "block", 15,  25.5,  17.1, "PaleGoldenrod" ],
+        [   2.5,  10.65, 270, "jst_xh", 2, false, grey(20), ],
+        [   2.5,  18.15, 270, "jst_xh", 2, false, grey(20), ],
+        [   2.5,  25.65, 270, "jst_xh", 2, false, grey(20), ],
+        [  11.0,   2.0,    0, "2p54header", 2, 1 ],
+        [  23.0,   2.0,    0, "2p54header", 4, 1 ],
+        [   7.9,  -3.3,   90, "2p54header", 2, 1 ],
+        [  -6.5,   2.45, 180, "terminal",   3, [10, 1.33, 13.2, 16, 7, 13] ],
+    ],
+    [], // accessories
+    [], // grid
+];
+
 BTT_SKR_MINI_E3_V2_0 = [
     "BTT_SKR_MINI_E3_V2_0", "BigTreeTech SKR Mini E3 v2.0",
     100.75, 70.25, 1.6, // size
@@ -882,7 +910,7 @@ KY_040 = ["KY_040", "KY-040 rotart encoder breakout",
 
 tiny_pcbs = [XIAO, MP1584EN, TP4056, ESP_01, LIPO_fuel_gauge];
 
-pcbs = [RAMPSEndstop, KY_040, MT3608, ZC_A0591, ArduinoNano, RPI_Pico, ESP32_DOIT_V1, RPI0, EnviroPlus, ArduinoUno3, ArduinoLeonardo, WD2002SJ, RPI3, RPI4, BTT_SKR_MINI_E3_V2_0, BTT_SKR_E3_TURBO, BTT_SKR_V1_4_TURBO, DuetE, Duex5];
+pcbs = [RAMPSEndstop, KY_040, MT3608, ZC_A0591, ArduinoNano, RPI_Pico, ESP32_DOIT_V1, RPI0, EnviroPlus, ArduinoUno3, ArduinoLeonardo, WD2002SJ, RPI3, RPI4, BTT_RELAY_V1_2, BTT_SKR_MINI_E3_V2_0, BTT_SKR_E3_TURBO, BTT_SKR_V1_4_TURBO, DuetE, Duex5];
 
 pcbs_not_shown = [Melzi, Duex2, PSU12V1A, Keyes5p1, PI_IO, ExtruderPCB];
 

--- a/vitamins/psu.scad
+++ b/vitamins/psu.scad
@@ -30,6 +30,7 @@ use <../utils/round.scad>
 use <fan.scad>
 use <iec.scad>
 use <rocker.scad>
+use <terminal.scad>
 
 function psu_face_holes(type)        = type[0];     //! List of screw hole positions
 function psu_face_thickness(type)    = type[1];     //! The thickness
@@ -54,65 +55,6 @@ function psu_right_bay(type)         = type[9];     //! Bay for heatsink
 function psu_terminals(type)         = type[10];    //! How many terminals and the y offset from the back
 function psu_faces(type)             = type[11];    //! List of face descriptions
 function psu_accessories(type)       = type[12];    //! Accessories to add to BOM, e.g. mains lead
-
-function terminal_block_pitch(type)   = type[0];    //! Pitch between screws
-function terminal_block_divider(type) = type[1];    //! Width of the dividers
-function terminal_block_height(type)  = type[2];    //! Height of the dividers
-function terminal_block_depth(type)   = type[3];    //! Total depth
-function terminal_block_height2(type) = type[4];    //! Height under the contacts
-function terminal_block_depth2(type)  = type[5];    //! Depth of contact well
-
-function terminal_block_length(type, ways) = terminal_block_pitch(type) * ways + terminal_block_divider(type); //! Total length of terminal block
-
-module terminal_block(type, ways) { //! Draw a power supply terminal block
-    tl = terminal_block_length(type, ways);
-    depth = terminal_block_depth(type);
-    depth2 = terminal_block_depth2(type);
-    div = terminal_block_divider(type);
-    h = terminal_block_height(type);
-    h2 = terminal_block_height2(type);
-    pitch = terminal_block_pitch(type);
-    back_wall = depth - depth2;
-    contact_depth = depth2 - back_wall;
-    contact_width = pitch - div;
-    contact_h = 0.4;
-    washer_t = 1.2;
-    translate([0, -tl]) {
-        color(grey(20)) {
-            cube([depth, tl, h2]);
-
-            translate([depth2, 0])
-                cube([depth - depth2, tl, h]);
-
-            for(i = [0 : ways])
-                translate([0, i * pitch + div])
-                    rotate([90, 0, 0])
-                        linear_extrude(div)
-                            hull() {
-                                r = 2;
-                                square([depth, eps]);
-
-                                translate([depth - eps, 0])
-                                    square([eps, h]);
-
-                                translate([r, h - r])
-                                    circle4n(r);
-                            }
-        }
-        color("silver")
-            for(i = [0 : ways - 1]) translate([0, i * pitch + div, h2]) {
-                translate([back_wall, 1])
-                    cube([contact_depth, contact_width - 2, contact_h]);
-
-                translate([back_wall + contact_depth / 2 - contact_width / 2, 0])
-                    cube([contact_width, contact_width, contact_h + washer_t]);
-
-                translate([back_wall + contact_depth / 2, contact_width / 2, contact_h + washer_t])
-                    not_on_bom() no_explode()
-                        screw(M3_pan_screw, 8);
-            }
-    }
-}
 
 function psu_face_transform(type, face) =           //! Returns a transformation matrix to get to the specified face
     let(l = psu_length(type),

--- a/vitamins/terminal.scad
+++ b/vitamins/terminal.scad
@@ -1,0 +1,79 @@
+//
+// NopSCADlib Copyright Chris Palmer 2018
+// nop.head@gmail.com
+// hydraraptor.blogspot.com
+//
+// This file is part of NopSCADlib.
+//
+// NopSCADlib is free software: you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// NopSCADlib is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with NopSCADlib.
+// If not, see <https://www.gnu.org/licenses/>.
+//
+
+include <../core.scad>
+
+function terminal_block_pitch(type)   = type[0];    //! Pitch between screws
+function terminal_block_divider(type) = type[1];    //! Width of the dividers
+function terminal_block_height(type)  = type[2];    //! Height of the dividers
+function terminal_block_depth(type)   = type[3];    //! Total depth
+function terminal_block_height2(type) = type[4];    //! Height under the contacts
+function terminal_block_depth2(type)  = type[5];    //! Depth of contact well
+
+function terminal_block_length(type, ways) = terminal_block_pitch(type) * ways + terminal_block_divider(type); //! Total length of terminal block
+
+module terminal_block(type, ways) { //! Draw a power supply terminal block
+    tl = terminal_block_length(type, ways);
+    depth = terminal_block_depth(type);
+    depth2 = terminal_block_depth2(type);
+    div = terminal_block_divider(type);
+    h = terminal_block_height(type);
+    h2 = terminal_block_height2(type);
+    pitch = terminal_block_pitch(type);
+    back_wall = depth - depth2;
+    contact_depth = depth2 - back_wall;
+    contact_width = pitch - div;
+    contact_h = 0.4;
+    washer_t = 1.2;
+    translate([0, -tl]) {
+        color(grey(20)) {
+            cube([depth, tl, h2]);
+
+            translate([depth2, 0])
+                cube([depth - depth2, tl, h]);
+
+            for(i = [0 : ways])
+                translate([0, i * pitch + div])
+                    rotate([90, 0, 0])
+                        linear_extrude(div)
+                            hull() {
+                                r = 2;
+                                square([depth, eps]);
+
+                                translate([depth - eps, 0])
+                                    square([eps, h]);
+
+                                translate([r, h - r])
+                                    circle4n(r);
+                            }
+        }
+        color("silver")
+            for(i = [0 : ways - 1]) translate([0, i * pitch + div, h2]) {
+                translate([back_wall, 1])
+                    cube([contact_depth, contact_width - 2, contact_h]);
+
+                translate([back_wall + contact_depth / 2 - contact_width / 2, 0])
+                    cube([contact_width, contact_width, contact_h + washer_t]);
+
+                translate([back_wall + contact_depth / 2, contact_width / 2, contact_h + washer_t])
+                    not_on_bom() no_explode()
+                        screw(M3_pan_screw, 8);
+            }
+    }
+}


### PR DESCRIPTION
Notes:

1. I used the wording "terminal" rather than "terminal_block" for the PCB keyword - not sure which you prefer.
2. The terminal block is not placed on the PCB relative to its centre - I can change that if you like.