### PR TITLE
Shaft coupling: Add flexible SC / 6x8 flexible SC

### DIFF
--- a/vitamins/shaft_coupling.scad
+++ b/vitamins/shaft_coupling.scad
@@ -26,6 +26,7 @@ function sc_length(type)       = type[1]; //! Coupling length
 function sc_diameter(type)     = type[2]; //! Coupling outer diameter
 function sc_diameter1(type)    = type[3]; //! Diameter of smaller shaft
 function sc_diameter2(type)    = type[4]; //! Diameter of larger shaft
+function sc_flexible(type)     = type[5]; //! Flexible coupling
 
 module shaft_coupling(type, colour = "silver") { //! Draw the shaft coupling
     vitamin(str("shaft_coupling(", type[0], "): Shaft coupling ", type[0]));
@@ -34,6 +35,7 @@ module shaft_coupling(type, colour = "silver") { //! Draw the shaft coupling
     radius = sc_diameter(type) / 2;
     r1 = sc_diameter1(type) / 2;
     r2 = sc_diameter2(type) / 2;
+    flexible = is_undef(sc_flexible(type)) ? false : sc_flexible(type);
 
     grub_length = 3;
     module grub_screw_positions() {
@@ -53,6 +55,11 @@ module shaft_coupling(type, colour = "silver") { //! Draw the shaft coupling
                     tube(radius, r1, length / 2, false);
 
                 tube(radius, r2, length / 2, false);
+            }
+            if (flexible) {
+                linear_extrude(length/3, center=true, convexity = 20, twist = -5 * 360)
+                    translate([r1,0,0])
+                       square(radius-r1,1); 
             }
             grub_screw_positions()
                 rotate([180, 0, 0])

--- a/vitamins/shaft_couplings.scad
+++ b/vitamins/shaft_couplings.scad
@@ -21,9 +21,9 @@
 //! Shaft couplings
 //
 
-//                                   L   D        d1   d2
-SC_5x8_rigid  = [ "SC_5x8_rigid",    25, 12.5,    5,   8 ];
-
-shaft_couplings = [SC_5x8_rigid];
+//                                   L   D        d1   d2 flex?
+SC_5x8_rigid  = [ "SC_5x8_rigid",    25, 12.5,    5,   8, false ];
+SC_6x8_flex   = [ "SC_6x8_flex",     25, 19,      6,   8, true ];
+shaft_couplings = [SC_5x8_rigid, SC_6x8_flex];
 
 use <shaft_coupling.scad>


### PR DESCRIPTION
Added the possibility for shaft couplings to be flexible and added a 6x8 example of such a coupling.

![shaftcouplings](https://user-images.githubusercontent.com/1951972/192097325-f415b93b-1329-4e09-9734-f7c38d09e151.png)

![](https://ae01.alicdn.com/kf/HTB1AeYecuGSBuNjSspbq6AiipXa8/Fixmee-6x8-mm-Motor-Jaw-Shaft-Coupler-6mm-To-8mm-Flexible-Coupling-OD-19x25mm-Whoelsale.jpg)

This is my first contribution to this project, so please let me know if there's anything I should have done differently.


