### PR TITLE
Include terminal.scad in lib.scad to allow use of terminal_block().

### DIFF
--- a/lib.scad
+++ b/lib.scad
@@ -63,6 +63,7 @@ include <vitamins/spools.scad>
 include <vitamins/ssrs.scad>
 include <vitamins/stepper_motors.scad>
 include <vitamins/swiss_clips.scad>
+include <vitamins/terminal.scad>
 include <vitamins/toggles.scad>
 include <vitamins/transformers.scad>
 include <vitamins/tubings.scad>


### PR DESCRIPTION
Add include of vitamins/termian.scad to lib.scad to allow using terminal_block() with only include of NopSCADlib/lib.scad.
