### PR TITLE
WiP of an Orange Pi Zero 2 PCB

### DIFF
--- a/vitamins/pcb.scad
+++ b/vitamins/pcb.scad
@@ -115,6 +115,14 @@ module usb_A_tongue() {
                 }
 }
 
+module usb_vAx1(cutout = false) { //! Draw USB type A single socket
+    translate([0,6.5/2,13.25/2]) {
+      rotate([90,0,0]) {
+        usb_A(h = 6.5, v_flange_l = 0, bar = 0, cutout = cutout, 14);
+      }
+    }
+}
+
 module usb_Ax1(cutout = false) { //! Draw USB type A single socket
     usb_A(h = 6.5, v_flange_l = 4.5, bar = 0, cutout = cutout);
 }
@@ -123,8 +131,7 @@ module usb_Ax2(cutout = false) { //! Draw USB type A dual socket
     usb_A(h = 15.6, v_flange_l = 12.15, bar = 3.4, cutout = cutout);
 }
 
-module usb_A(h, v_flange_l, bar, cutout) {
-    l = 17;
+module usb_A(h, v_flange_l, bar, cutout, l=17) {
     w = 13.25;
     flange_t = 0.4;
     h_flange_h = 0.8;
@@ -1088,6 +1095,7 @@ module pcb_component(comp, cutouts = false, angle = undef) { //! Draw pcb compon
         if(show(comp, "chip"))          chip(comp[4], comp[5], comp[6], param(7, grey(30)), cutouts);
         if(show(comp, "rj45"))          rj45(cutouts);
         if(show(comp, "usb_A"))         usb_Ax1(cutouts);
+        if(show(comp, "usb_vAx1"))      usb_vAx1(cutouts);
         if(show(comp, "usb_Ax1"))       usb_Ax1(cutouts);
         if(show(comp, "usb_Ax2"))       usb_Ax2(cutouts);
         if(show(comp, "usb_uA"))        usb_uA(cutouts);

--- a/vitamins/pcbs.scad
+++ b/vitamins/pcbs.scad
@@ -537,6 +537,26 @@ Melzi = ["Melzi", "Melzi electronics", 203.2, 49.53, 1.6, 3.81, 3.1,  6, "green"
                                                                     [],
                                                                     [": USB A to Mini B lead", ": Micro SD card"]];
 
+OPZ2 =  ["OPZ2", "Orange Pi Zero 2",     60,    53,    1.4, 1.75,    3, 5, "blue", false, [[2.5, 2.5], [-2.5, 2.5], [-2.5, -2.5], [2.5, -2.5]],
+    [[-2.54, 53/2, 90, "2p54header", 13, 2],
+     [-10, -10-2.54*2, 0, "2p54header", 3, 1],
+     [2.54/2, 53/2, 90, "2p54header", 13, 1],
+     [6+16/2, -10.5+1, 90, "rj45"],
+     [24+9/2, -3.6+1, 90, "usb_C"],
+     [37+6.5/2,  -8.5/2+1, 90, "micro_hdmi"],
+     // FIXME: USB A connector is 5.8mm wide, ~13.8mm deep, ~13.8mm high
+     // FIXME: USB A socket tongue/tab is too long
+     // FIXME: USB A socket does not have flanges
+     [-7-5.8/2, -7+1,    90, "usb_vAx1"],
+     [-17,   18,  0, "chip",       13, 7.5, 1],
+     [-17,   28,  0, "chip",       13, 7.5, 1],
+     [26,   23,  0, "chip",       12.2, 14, 1],
+     [8.1+10.3/2,   3.7+10.3/2,  0, "chip",       10.3, 10.3, 1.8, "silver"],
+     [10.7+14.6/2,  14.7/2,  90, "-uSD", [14.6, 14.7, 2]],
+    ],
+    [": Micro SD card"],
+    [60-2.54*1.5, 53/2 - 6*2.54, 2, 13]];
+
 RPI3A =  ["RPI3A", "Raspberry Pi 3 A+",     65,    56,    1.4, 3,    2.75, 6, "green", false, [[3.5, 3.5], [61.5, 3.5], [61.5, -3.5], [3.5, -3.5]],
     [[32.5, -3.5,   0, "2p54header", 20, 2],
      [27,   -24.6,  0, "chip",       14, 14, 1],
@@ -954,7 +974,7 @@ L9110S = ["L9110S", "L9110S 2-Channel motor driver module", 29.2, 23, 1.6, 0, 3,
 
 tiny_pcbs = [XIAO, MP1584EN, TP4056, ESP_01, LIPO_fuel_gauge];
 
-pcbs = [RAMPSEndstop, MT3608, KY_040, L9110S, ZC_A0591, ArduinoNano, RPI_Pico, ESP32_DOIT_V1, RPI0, EnviroPlus, ArduinoUno3, ArduinoLeonardo, WD2002SJ, RPI3A, RPI3, RPI4, BTT_RELAY_V1_2, BTT_SKR_MINI_E3_V2_0, BTT_SKR_E3_TURBO, BTT_SKR_V1_4_TURBO, DuetE, Duex5];
+pcbs = [RAMPSEndstop, MT3608, KY_040, L9110S, ZC_A0591, ArduinoNano, RPI_Pico, ESP32_DOIT_V1, OPZ2, RPI0, RPI3A, EnviroPlus, ArduinoUno3, ArduinoLeonardo, WD2002SJ, RPI3A, RPI3, RPI4, BTT_RELAY_V1_2, BTT_SKR_MINI_E3_V2_0, BTT_SKR_E3_TURBO, BTT_SKR_V1_4_TURBO, DuetE, Duex5];
 
 pcbs_not_shown = [Melzi, Duex2, PSU12V1A, Keyes5p1, PI_IO, ExtruderPCB];
 


### PR DESCRIPTION
Hello again, nice people/person!

Since Raspberry Pis are so hard to come by these days, I've picked up an Orange Pi Zero 2, and I've added it as a PCB.

There are a few issues with it, though, mostly centered around the vertical USB A socket:
* The dimensions of the socket are off from what is in NopSCADlib, and (unlike the microsd socket) there is no way to alter the dimensions.
* Related, I started adding an ability to override the dimensions via a proof-of-concept "usb_vAx1" vertical USB A socket that I do not much care for, so thought it would be good to get some feedback before I proceed further.
* The socket does not have any 90 degree flanges. I can turn off some of the flanges, but not all.

Thank you in advance for any guidance you might have, and thank you again for this library!
