### PR TITLE
Add  RCWL-0516 PCB

### DIFF
--- a/vitamins/pcbs.scad
+++ b/vitamins/pcbs.scad
@@ -1201,6 +1201,28 @@ ESP_12F = pcb("ESP_12F", "ESP-12F ESP8266 WiFi module", [24, 16, 0.8],
         ]
     ]
 );
+            
+RCWL0516 = pcb(
+    "RCWL-0516", "Microwave Radar Sensor",
+    size = [36, 17.3, 1.2],
+    colour = "#17682d",
+    hole_d = 1.7,
+    holes = [
+          [  inch(0.05),  inch(0.05) ],
+          [ -inch(0.05),  inch(0.05) ],
+          [ -inch(0.05), -inch(0.05) ],
+          [  inch(0.05), -inch(0.05) ],
+          [ -inch(0.65), -inch(0.05) ],
+          [ -inch(0.65),  inch(0.05) ],
+    ],
+    grid = [inch(0.05), inch(0.13), 1,  5, silver, inch(0.1), inch(0.1)],
+  components = [
+        [inch(0.18), inch(0.13), 90,"smd_cap", CAP1206, 0.5],
+        [inch(0.18), inch(0.32), 90,"smd_cap", CAP1206, 0.5],
+        [inch(0.18), inch(0.54), 90,"smd_cap", CAP1206, 0.5],
+        [inch(0.45), inch(0.34),  0,"smd_soic", SOIC16, "RCWL9196"],
+            ]
+);
 
 tiny_buck = pcb("tiny_buck", "Ultra Small 3A buck regulator", [20, 11, 1.6],
     hole_d = 1.2,
@@ -1226,7 +1248,7 @@ tiny_pcbs = [ESP_201, ESP_01M, XIAO, ESP_12F, MP1584EN, ESP_01,tiny_buck, LIPO_f
 
 big_pcbs = [BTT_RELAY_V1_2, BTT_SKR_MINI_E3_V2_0, BTT_SKR_E3_TURBO, BTT_SKR_V1_4_TURBO, DuetE, Duex5];
 
-pcbs = [KY_040, TP4056, L9110S, ZC_A0591, MT3608, RAMPSEndstop, ArduinoNano, HW803_1WAY_RELAY, Feather405, RPI_Pico, ESP32_DOIT_V1, RPI0, EnviroPlus, ArduinoUno3, ArduinoLeonardo, WD2002SJ, OPZ2, PanelDue_v3, RPI3A, RPI3, RPI4];
+pcbs = [KY_040, TP4056, L9110S, ZC_A0591, MT3608, RAMPSEndstop, ArduinoNano, HW803_1WAY_RELAY, Feather405, RPI_Pico, ESP32_DOIT_V1, RPI0, EnviroPlus, ArduinoUno3, ArduinoLeonardo, WD2002SJ, OPZ2, PanelDue_v3, RPI3A, RPI3, RPI4, RCWL0516];
 
 pcbs_not_shown = [Melzi, Duex2, PSU12V1A, Keyes5p1, PI_IO, ExtruderPCB];
 


### PR DESCRIPTION
PCB for the RCWL-0516 module.

![Screenshot 2024-04-20 130843](https://github.com/nophead/NopSCADlib/assets/1160510/72f8c033-94c1-4916-aafb-fcb218202eab)

Real module:
![PXL_20240420_101037464](https://github.com/nophead/NopSCADlib/assets/1160510/c9cbe10c-e9c4-464e-b8bb-941822151373)
