### PR TITLE
Relative paths for vitamin rod_end includes

### DIFF
--- a/vitamins/rod_end.scad
+++ b/vitamins/rod_end.scad
@@ -20,8 +20,8 @@
 //
 //! A rod end, sometimes called a spherical bearing or rod-end eye, is a component used in mechanical systems to create a flexible connection between two parts.
 //
-include <NopSCADlib/utils/core/core.scad>
-include <NopSCADlib/utils/thread.scad>
+include <../utils/core/core.scad>
+include <../utils/thread.scad>
 
 function rod_end_bearing_bore(type)          = type[1];    //! radius of the  bore hole in the bearing
 function rod_end_bearing_od(type)            = type[2];    //! Outer diameter of the bearing


### PR DESCRIPTION
When attempting to use NopSCADlib as a git submodule within my project, I encountered the following warnings while including lib.scad:
```
Can't open included file "NopSCADlib/utils/core/core.scad.
Can't open included file "NopSCADlib/utils/thread.scad.
```
Upon investigation, I found that most SCAD files in the library use relative paths, but vitamins/rod_end.scad did not conform. I conformed it.

I realize using NopSCADlib as a submodule is not discussed in the usage section of the readme. With this change everything seems to load correctly when opening libtest.scad and including lib.scad as a relative path.  Sorry if this change is a mistake I have very little experience with openSCAD.