### PR TITLE
Added motor in the back functionality for core_xy scheme

### DIFF
--- a/tests/core_xy.scad
+++ b/tests/core_xy.scad
@@ -132,5 +132,55 @@ module coreXY_belts_test() {
     }
 }
 
+module coreXY_motor_in_back_test1() {
+    size = [200,200];
+    pos = [100,100];
+    separation = [20,5,10];
+    
+
+    coreXY(coreXY_GT2_20_16, size, pos, separation, x_gap = 0, plain_idler_offset = [0, 0], upper_drive_pulley_offset = [0, 0], lower_drive_pulley_offset = [0, 0], show_pulleys = true, left_lower = false, motor_back = true);
+    
+    rotate([180,0,0])
+    translate (
+        [ separation.x/2
+        , 0
+        , -separation.z/2 -15 ])
+    NEMA(NEMA17_40);
+    translate (
+        [ size.x - separation.x/2
+        , 0
+        , -separation.z/2 - 15 ])
+    NEMA(NEMA17_40);
+}
+
+module coreXY_motor_in_back_test2() {
+    size = [200,200];
+    pos = [100,100];
+    separation = [0,5,10];
+    upper_drive_pulley_offset = [20, 5];
+    lower_drive_pulley_offset = [20, 5];
+    
+
+    coreXY(coreXY_GT2_20_16, size, pos, separation, x_gap = 0, plain_idler_offset = [20, 0], upper_drive_pulley_offset, lower_drive_pulley_offset, show_pulleys = true, left_lower = false, motor_back = true);
+    
+    translate (
+        [ size.x - separation.x/2 - lower_drive_pulley_offset.x
+        , lower_drive_pulley_offset.y
+        , -separation.z/2 - 15 ])
+    NEMA(NEMA17_40);
+    
+    translate (
+        [ separation.x/2 + upper_drive_pulley_offset.x
+        , upper_drive_pulley_offset.y
+        , separation.z/2 - 25 ])
+    NEMA(NEMA17_40);
+}
+
+
 if ($preview)
     coreXY_belts_test();
+    translate ([-250, 0,0])
+        coreXY_motor_in_back_test1();
+        
+    translate ([-250, -250,0])
+        coreXY_motor_in_back_test2();

--- a/utils/core_xy.scad
+++ b/utils/core_xy.scad
@@ -71,13 +71,15 @@ function coreXY_drive_plain_idler_offset(type) = //! Offset of plain drive idler
 module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_offset = [0, 0], drive_pulley_offset = [0, 0], show_pulleys = false, lower_belt = false, hflip = false, motor_back = false) { //! Draw one belt of a coreXY setup
 
     // y-carriage toothed pulley
-    p0_type = coreXY_toothed_idler(type);
+    p0t_type = coreXY_toothed_idler(type);
     p0p_type = coreXY_plain_idler(type);
-    p0 = [ size.x / 2, -size.y / 2 - pulley_od(p0_type) / 2 + pos.y - separation_y / 2 ];
+    p0t = [ size.x / 2, -size.y / 2 - pulley_od(p0t_type) / 2 + pos.y - separation_y / 2 ];
+    p0p = [ size.x / 2, -size.y / 2 - pulley_od(p0p_type) / 2 + pos.y - separation_y / 2 ];
+    
 
     // bottom right toothed idler pulley
-    p1_type = p0_type;
-    p1p_type = coreXY_plain_idler(type);
+    p1t_type = p0t_type;
+    p1p_type = p0p_type;
     p1 = [ size.x / 2, -size.y / 2 ];
 
     // bottom left anchor toothed idler pulley
@@ -86,13 +88,14 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
     
     //drive type if the motor is in the back
     p2d_type = coreXY_drive_pulley(type);
-    p2d = [ p2.x + drive_pulley_offset.x,
+    p2d = [ lower_belt ? p2.x - drive_pulley_offset.x:p2.x + drive_pulley_offset.x,
             p2.y + drive_pulley_offset.y 
     ];
+   
     
     // plain idler for offset stepper motor if the motor is in the back
     p2p_type = coreXY_plain_idler(type);
-    p2p = [ p2.x + plain_idler_offset.x + drive_pulley_offset.x,
+    p2p = [ lower_belt ? p2.x + plain_idler_offset.x - drive_pulley_offset.x : p2.x + plain_idler_offset.x + drive_pulley_offset.x,
             p2.y + plain_idler_offset.y 
     ];
 
@@ -104,7 +107,7 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
 
     // toothed idler for offset stepper motor drive pulley if motor not in back
     p3t_type = coreXY_toothed_idler(type);
-    p3t = [ -size.x / 2 + (drive_pulley_offset.x > 0 ? 0 : plain_idler_offset.x + 2 * coreXY_drive_pulley_x_alignment(type)),
+    p3t = [ -size.x / 2 + ((drive_pulley_offset.x > 0 || motor_back ) ? 0 : plain_idler_offset.x + 2 * coreXY_drive_pulley_x_alignment(type)),
              size.y / 2 + coreXY_drive_pulley_x_alignment(type)
     ];
 
@@ -119,7 +122,7 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
 
     // plain idler for offset stepper motor drive pulley if motor not in back
     p3p_type = p4_type;
-    p3p = [ drive_pulley_offset.x > 0 ? p4.x : -p0.x - pulley_od(p0_type),
+    p3p = [ drive_pulley_offset.x > 0 ? p4.x : -p0p.x - pulley_od(p0p_type),
             size.y / 2 - pulley_od(p3p_type) / 2 - pulley_od(p3d_type) / 2 + plain_idler_offset.y
     ];
 
@@ -127,7 +130,7 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
     start_p = [ pos.x - size.x / 2 + x_gap / 2, -size.y / 2 + pos.y - separation_y / 2, 0 ];
     end_p   = [ pos.x - size.x / 2 - x_gap / 2, -size.y / 2 + pos.y + separation_y / 2, 0 ];
 
-    //p6_type = p0_type;
+    //p6_type = p0p_type;
 
     module show_pulleys(show_pulleys) {// Allows the pulley colour to be set for debugging
         if (is_list(show_pulleys))
@@ -139,10 +142,10 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
 
     show_pulleys(show_pulleys) {
         if ( !motor_back ) {
-            translate(p0)
-                pulley_assembly(p0_type); // y-carriage toothed pulley
+            translate(p0t)
+                pulley_assembly(p0t_type); // y-carriage toothed pulley
             translate(p1)
-                pulley_assembly(p1_type); // bottom right toothed idler pulley
+                pulley_assembly(p1t_type); // bottom right toothed idler pulley
             translate(p2)
                 pulley_assembly(p2_type); // bottom left anchor toothed idler pulley
         
@@ -162,7 +165,7 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
         }
         else {  //motor in the back
             if (drive_pulley_offset.x ) { // idler pulleys for offset stepper motor drive pulley
-                translate(p0)
+                translate(p0p)
                     pulley_assembly(p0p_type); // y-carriage plain pulley
                 translate(p1)
                     pulley_assembly(p1p_type); // bottom right plain idler pulley
@@ -183,15 +186,21 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
                 translate(p4mb)
                     pulley_assembly(p4t_type); // y-carriage toothed pulley
             } else {
-                translate(p0)
-                    pulley_assembly(p0_type); // y-carriage toothed pulley
+                translate(p0t)
+                    pulley_assembly(p0t_type); // y-carriage toothed pulley
                 translate(p1)
-                    pulley_assembly(p1_type); // bottom right toothed idler pulley
+                    pulley_assembly(p1t_type); // bottom right toothed idler pulley
             
                 //left bottom corner
+                
+                // bottom left stepper motor drive pulley
                 translate(p2)
-                    hflip(hflip)
-                        pulley_assembly(p2d_type); // bottom left stepper motor drive pulley
+                    if(lower_belt) 
+                        hflip(hflip)
+                            pulley_assembly(p2d_type); 
+                    else
+                        hflip(!hflip)
+                            pulley_assembly(p2d_type); 
                         
                 translate(p3t)
                     pulley_assembly(p3t_type); // top left toothed idler
@@ -205,8 +214,8 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
     }
 
     path0a = [
-        [ p0.x, p0.y, pulley_od(p0_type) / 2 ],
-        [ p1.x, p1.y, pulley_od(p1_type) / 2 ],
+        [ p0p.x, p0p.y, pulley_od(p0p_type) / 2 ],
+        [ p1.x, p1.y, pulley_od(p1p_type) / 2 ],
         [ p2.x, p2.y, pulley_od(p2_type) / 2 ]
     ];
     path0b = [
@@ -231,20 +240,20 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
     path0 = drive_pulley_offset.x == 0  ? concat(path0a, path0b) : drive_pulley_offset.x > 0 ? concat(path0a, path0c) : concat(path0a, path0d);
     
     path_mb_0a = [
-        [ p0.x, p0.y, pulley_od(p0_type) / 2 ],
-        [ p1.x, p1.y, pulley_od(p1_type) / 2 ],
+        [ p0p.x, p0p.y, pulley_od(p0p_type) / 2 ],
+        [ p1.x, p1.y, pulley_od(p1p_type) / 2 ],
         [ p2.x, p2.y, pulley_od(p2d_type) / 2 ],
         [ p3t.x, p3t.y, pulley_od(p3t_type) / 2 ],
         [ p4mb.x, p4mb.y, -pulley_od(p4_type) / 2 ]
     ];
     
     path_mb_0b = [
-        [ p0.x, p0.y, pulley_od(p0_type) / 2 ],
-        [ p1.x, p1.y, pulley_od(p1_type) / 2 ],
+        [ p0t.x, p0t.y, pulley_od(p0t_type) / 2 ],
+        [ p1.x, p1.y, pulley_od(p1p_type) / 2 ],
         [ p2p.x, p2p.y, pulley_od(p2p_type) / 2 ],
         [ p2d.x, p2d.y, -pulley_od(p2d_type) / 2 ],
-        [ p2.x, p2.y, pulley_od(p2_type) / 2 ],
-        [ p3t.x, p3t.y, pulley_od(p3t_type) / 2 ],
+        [ p2.x, p2.y, pulley_od(p2p_type) / 2 ],
+        [ p3t.x, p3t.y, pulley_od(p3p_type) / 2 ],
         [ p4mb.x, p4mb.y, -pulley_od(p4_type) / 2 ]
     ];
     
@@ -258,18 +267,18 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
         tooth_colour = lower_belt ? coreXY_lower_tooth_colour(type) : coreXY_upper_tooth_colour(type));
 }
 
-module coreXY(type, size, pos, separation, x_gap = 0, plain_idler_offset = [0, 0], upper_drive_pulley_offset = [0, 0], lower_drive_pulley_offset = [0, 0], show_pulleys = false, left_lower = false) { //! Wrapper module to draw both belts of a coreXY setup
+module coreXY(type, size, pos, separation, x_gap = 0, plain_idler_offset = [0, 0], upper_drive_pulley_offset = [0, 0], lower_drive_pulley_offset = [0, 0], show_pulleys = false, left_lower = false, motor_back = false) { //! Wrapper module to draw both belts of a coreXY setup
     translate([size.x / 2 - separation.x / 2, size.y / 2, -separation.z / 2]) {
         // lower belt
         hflip(!left_lower)
             explode(25)
-                coreXY_half(type, size, [size.x - pos.x - separation.x/2 - (left_lower ? x_gap : 0), pos.y], separation.y, x_gap, plain_idler_offset, [-lower_drive_pulley_offset.x, lower_drive_pulley_offset.y], show_pulleys, lower_belt = true, hflip = true);
+                coreXY_half(type, size, [size.x - pos.x - separation.x/2 - (left_lower ? x_gap : 0), pos.y], separation.y, x_gap, plain_idler_offset, [-lower_drive_pulley_offset.x, lower_drive_pulley_offset.y], show_pulleys, lower_belt = true, hflip = true, motor_back);
 
         // upper belt
         translate([separation.x, 0, separation.z])
             hflip(left_lower)
                 explode(25)
-                    coreXY_half(type, size, [pos.x + separation.x/2 + (left_lower ? x_gap : 0), pos.y], separation.y, x_gap, plain_idler_offset, upper_drive_pulley_offset, show_pulleys, lower_belt = false, hflip = false);
+                    coreXY_half(type, size, [pos.x + separation.x/2 + (left_lower ? x_gap : 0), pos.y], separation.y, x_gap, plain_idler_offset, upper_drive_pulley_offset, show_pulleys, lower_belt = false, hflip = false, motor_back);
     }
 }
 

--- a/utils/core_xy.scad
+++ b/utils/core_xy.scad
@@ -163,12 +163,12 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
         else {  //motor in the back
             if (drive_pulley_offset.x ) { // idler pulleys for offset stepper motor drive pulley
                 translate(p0)
-                    pulley_assembly(p0p_type); // y-carriage toothed pulley
+                    pulley_assembly(p0p_type); // y-carriage plain pulley
                 translate(p1)
-                    pulley_assembly(p1p_type); // bottom right toothed idler pulley
+                    pulley_assembly(p1p_type); // bottom right plain idler pulley
                 //left bottom corner
                 translate(p2)
-                       pulley_assembly(p2p_type); // toothed idler
+                       pulley_assembly(p2p_type); // plain idler
                         
                 translate(p2p)
                     pulley_assembly(p2p_type); // plain idler
@@ -178,10 +178,10 @@ module coreXY_half(type, size, pos, separation_y = 0, x_gap = 0, plain_idler_off
                         pulley_assembly(p2d_type); // bottom left stepper motor drive pulley
                         
                 translate(p3t)
-                    pulley_assembly(p3p_type); // top left toothed idler
+                    pulley_assembly(p3p_type); // top left plain idler
             
                 translate(p4mb)
-                    pulley_assembly(p4t_type); // y-carriage plain pulley
+                    pulley_assembly(p4t_type); // y-carriage toothed pulley
             } else {
                 translate(p0)
                     pulley_assembly(p0_type); // y-carriage toothed pulley


### PR DESCRIPTION
Hi,

So i wanted to make a design based on the coreXY principle, but due to my previous experience with the voron project, i preferred to have the stepper motors in the back, so i could use the front for easy tensioning. The stepper motor in front would add unwanted vibrations to this tensioning mechanism.

In order to solve this, the motors can be emplaced in the back (see the two new test cases i added to the right)
<img width="630" alt="Screenshot 2025-02-16 at 12 28 21" src="https://github.com/user-attachments/assets/49027fc8-6deb-4a10-9b93-14efcdb16f1f" />

All variables and settings should work as expected, just with an extra motor_back bool that changes the setup.
