### PR TITLE
Added a 1602 LCD display with I2C interface module

### DIFF
--- a/vitamins/displays.scad
+++ b/vitamins/displays.scad
@@ -46,7 +46,26 @@ LCD1602APCB = pcb("", "", [80, 36, 1.65], hole_d = 2.9, land_d = 5, colour = "gr
     ]
 );
 
+LCD1602APCBI2C = pcb("", "", [80, 36, 1.65], hole_d = 2.9, land_d = 5, colour = "green",
+    holes = [[-2.5, -2.5], [-2.5, 2.5], [2.5, 2.5], [2.5, -2.5]],
+    components = [
+        [-27.05, - 2.5, 0, "2p54header", 16, 1],
+        [ -27.05, -10.0, 0, "pcb", 3, I2C_LCD_Backpack],
+    ],
+    grid = [
+          52.95 - inch(0.75), 36 - 2.5, 16, 1, silver, inch(0.1), inch(0.1),
+    ]
+);
+
 LCD1602A = ["LCD1602A", "LCD display 1602A", 71.3, 24.3, 7.0, LCD1602APCB,
+          [0, 0, 0],                             // pcb offst
+          [[-64.5 / 2, -14.5 / 2], [64.5 / 2, 14.5 / 2, 0.6]],              // aperture
+          [],                                       // touch screen
+          0,                                        // thread length
+          [],                                       // clearance need for the ts ribbon
+        ];
+
+LCD1602AI2C = ["LCD1602A", "LCD display 1602A", 71.3, 24.3, 7.0, LCD1602APCBI2C,
           [0, 0, 0],                             // pcb offst
           [[-64.5 / 2, -14.5 / 2], [64.5 / 2, 14.5 / 2, 0.6]],              // aperture
           [],                                       // touch screen

--- a/vitamins/pcb.scad
+++ b/vitamins/pcb.scad
@@ -1097,6 +1097,56 @@ module trimpot10(vertical, cutout = false) { //! Draw a ten turn trimpot
              }
 }
 
+//! Draw a 1/4" square trimpot (https://ar.mouser.com/datasheet/2/54/3362-776956.pdf)
+module trimpot3362() {
+    l = 6.60;
+    w = 6.99;
+    h = 4.88;
+    foot_w = 0.38;
+    foot_h = 0.38;
+    screw_h = 0;
+    screw_d = 2.25;
+    slot_w =  0.6;
+    slot_h = 0.8;
+
+    module adjust(){
+      d = 2.77;
+      width = 0.64;
+      deep = 0.89;
+
+      color("white"){
+        difference(){
+          cylinder(d=d, h=2*deep, center=true);
+          translate([0, 0, deep-deep/2+0.01])
+            cube([d, width, deep], center=true);
+          translate([0, 0, deep-deep/2+0.01]) rotate([0, 0, 90])
+            cube([d, width, deep], center=true);
+        }
+      }
+    }
+
+    color("#2CA1FD") {
+      difference(){
+      translate([0, 0, foot_h / 2 + h / 2])
+        cube([w, l, h - foot_h], center = true);
+      translate_z(h-0.88) hull() adjust();
+      //Grub
+      for(ang=[-30:30:210])
+        rotate([0, 0, ang])
+        translate([2.77/2+0.46, 0, h]) cube([1, 0.3, 0.3], center=true);
+      }
+
+      for(x = [-1, 1], y = [1, -1])
+        translate([x * (w - foot_w) / 2, y * (l - foot_w) / 2, h / 2])
+          cube([foot_w, foot_w, h], center = true);
+
+      for(x = [-1, 1])
+        translate([x*(w/2-1), -l/2, h/2+foot_h/2])
+          cube([0.7, 0.7, h-foot_h], center=true);
+    }
+    translate([0, 0, h-0.89]) adjust();
+}
+
 module block(size, colour, makes_cutout, cutouts, r = 0, rtop = 0) //! Draw a coloured cube to represent a random PCB component
     if(cutouts) {
         if(makes_cutout)
@@ -1181,6 +1231,7 @@ module pcb_component(comp, cutouts = false, angle = undef) { //! Draw pcb compon
             if(show(comp, "jst_ph"))        jst_xh_header(jst_ph_header, comp[4], param(5, false), param(6, false), param(7, undef));
             if(show(comp, "jst_zh"))        jst_xh_header(jst_zh_header, comp[4], param(5, false), param(6, false), param(7, undef));
             if(show(comp, "potentiometer")) let(pot = param(4, BTT_encoder)) translate_z(pot_size(pot).z) vflip() potentiometer(pot, shaft_length = param(5, undef));
+            if(show(comp, "trimpot3362"))   trimpot3362();
             if(show(comp, "buzzer"))        buzzer(param(4, 9), param(5, 12), param(6, grey(20)));
             if(show(comp, "smd_250V_fuse")) smd_250V_fuse(comp[4], comp[5]);
             if(show(comp, "smd_res"))       smd_resistor(comp[4], comp[5]);

--- a/vitamins/pcbs.scad
+++ b/vitamins/pcbs.scad
@@ -1296,7 +1296,24 @@ tiny_buck = pcb("tiny_buck", "Ultra Small 3A buck regulator", [20, 11, 1.6],
     grid = [inch(0.05), 11 / 2 - inch(0.15), 1, 4, "silver", 0, inch(0.1)]
 );
 
-tiny_pcbs = [ESP_201, ESP_01M, XIAO, ESP_12F, MP1584EN, ESP_01,tiny_buck, LIPO_fuel_gauge, 9DOF_stick];
+I2C_LCD_Backpack = let(size=[42, 19, 1.2])
+  pcb("I2C_LCD_Backpack", "I2C / SPI character LCD backpack",
+      size = size, //size
+      colour = "black",
+      components = [[size[0]-2, -size[1]/2, 90, "2p54header", 4, 1, false, undef, true],
+                    [2, size[1]-8.5, 270, "2p54header", 2, 1, false, false, true],
+                    [size[0]/2,  size[1]/2,  90, "smd_soic", SOIC16, "PCF8574"],
+                    [size[0]*3/4,  11,  0, "trimpot3362"],
+                    // Silkscreen
+                    [size[0]*3/4+6, size[1]-5.8, 0, "text", 3, 1, "GND", "Liberation Sans:style=Bold"],
+                    [size[0]*3/4+6, size[1]-5.8-2.54, 0, "text", 3, 1, "VCC", "Liberation Sans:style=Bold"],
+                    [size[0]*3/4+6, size[1]-5.8-2.54*2, 0, "text", 3, 1, "SDA", "Liberation Sans:style=Bold"],
+                    [size[0]*3/4+6, size[1]-5.8-2.54*3, 0, "text", 3, 1, "SCL", "Liberation Sans:style=Bold"]
+                    ],
+      grid = [2, size[1]-2, 16, 1, silver, inch(0.1), inch(0.9)]
+      );
+
+tiny_pcbs = [ESP_201, ESP_01M, XIAO, ESP_12F, MP1584EN, ESP_01,tiny_buck, LIPO_fuel_gauge, 9DOF_stick, I2C_LCD_Backpack];
 
 big_pcbs = [BTT_RELAY_V1_2, BTT_SKR_MINI_E3_V2_0, BTT_SKR_E3_TURBO, BTT_SKR_V1_4_TURBO, DuetE, Duex5];
 


### PR DESCRIPTION
I added a [1/4" square trimpot](https://ar.mouser.com/ProductDetail/Bourns/3362F-1-254LF?qs=%2FxQVPCMPNzjxPTCOgN1%2Fdw%3D%3D) to the libary.

![image](https://github.com/user-attachments/assets/0bc54673-e86a-4036-a7c2-3eb6e0c6d547)

Added a pcb for the 1602 LCD I2C interface

![image](https://github.com/user-attachments/assets/d2bf0f21-ca22-4c5e-ac10-3b402dae3b80)

Finally, I added a new 1602 LCD display with the I2C module incorporated.

![image](https://github.com/user-attachments/assets/de894fa3-21ac-46fe-a0e8-f86677c2e6e5)

