### PR TITLE
positional parameters should not follow named parameters

### DIFF
--- a/tests/core_xy.scad
+++ b/tests/core_xy.scad
@@ -161,7 +161,7 @@ module coreXY_motor_in_back_test2() {
     lower_drive_pulley_offset = [20, 5];
 
 
-    coreXY(coreXY_GT2_20_16, size, pos, separation, x_gap = 0, plain_idler_offset = [20, 0], upper_drive_pulley_offset, lower_drive_pulley_offset, show_pulleys = true, left_lower = false, motor_back = true);
+    coreXY(coreXY_GT2_20_16, size, pos, separation, x_gap = 0, plain_idler_offset = [20, 0], upper_drive_pulley_offset = upper_drive_pulley_offset, lower_drive_pulley_offset = lower_drive_pulley_offset, show_pulleys = true, left_lower = false, motor_back = true);
 
     translate (
         [ size.x - separation.x/2 - lower_drive_pulley_offset.x

--- a/utils/core_xy.scad
+++ b/utils/core_xy.scad
@@ -272,13 +272,13 @@ module coreXY(type, size, pos, separation, x_gap = 0, plain_idler_offset = [0, 0
         // lower belt
         hflip(!left_lower)
             explode(25)
-                coreXY_half(type, size, [size.x - pos.x - separation.x/2 - (left_lower ? x_gap : 0), pos.y], separation.y, x_gap, plain_idler_offset, [-lower_drive_pulley_offset.x, lower_drive_pulley_offset.y], show_pulleys, lower_belt = true, hflip = true, motor_back);
+                coreXY_half(type, size, [size.x - pos.x - separation.x/2 - (left_lower ? x_gap : 0), pos.y], separation.y, x_gap, plain_idler_offset, [-lower_drive_pulley_offset.x, lower_drive_pulley_offset.y], show_pulleys, lower_belt = true, hflip = true, motor_back = motor_back);
 
         // upper belt
         translate([separation.x, 0, separation.z])
             hflip(left_lower)
                 explode(25)
-                    coreXY_half(type, size, [pos.x + separation.x/2 + (left_lower ? x_gap : 0), pos.y], separation.y, x_gap, plain_idler_offset, upper_drive_pulley_offset, show_pulleys, lower_belt = false, hflip = false, motor_back);
+                    coreXY_half(type, size, [pos.x + separation.x/2 + (left_lower ? x_gap : 0), pos.y], separation.y, x_gap, plain_idler_offset, upper_drive_pulley_offset, show_pulleys, lower_belt = false, hflip = false, motor_back = motor_back);
     }
 }
 


### PR DESCRIPTION
Some versions of OpenSCAD (like the latest official release 2021.01 get confused if positional parameters follow named parameters. So let's use named parameters after the first named one was used.