### PR TITLE
Fix for CGAL Error

### DIFF
--- a/utils/offset.scad
+++ b/utils/offset.scad
@@ -27,7 +27,7 @@ include <../utils/core/core.scad>
 module offset_3D(r, chamfer_base = false) { //! Offset 3D shape by specified radius `r`, positive or negative.
     module ball(r)
         if(chamfer_base)
-            rotate_extrude()
+            rotate_extrude(start=0)
                 intersection() {
                     rotate(180)
                         teardrop(0, r);


### PR DESCRIPTION
Fixes the following error when running recent OpenSCAD versions

```
WARNING: CGAL error in CGAL_Nef_polyhedron3(): CGAL ERROR: assertion violation!
Expr: e_below != SHalfedge_handle()
File: /usr/include/CGAL/Nef_3/SNC_FM_decorator.h
Line: 418. Attempting union...
WARNING: CGALUtils::convertSurfaceMeshToNef: Discarded 80 facets during Nef conversion.
```

Now the tests.py runs with the git version of OpenSCAD, with only `offset.scad` and `round.scad` failing with the error
```
WARNING: [manifold] Minkowski failed with error, falling back to Nef operation: bad any_cast
```
This is https://github.com/openscad/openscad/issues/6083 / https://github.com/openscad/openscad/issues/5862
and these are only warnings, the actual result still works. 

If I temporary sabotage `openscad.py` and `bom.py` to not fail on warnings, the tests run and the resulting png is virtually identical to the ones currently in git.